### PR TITLE
[Lot3] n°15 ETQ Bénéficiaire : modifier la condition d'affichage de la question « Êtes-vous à la retraite » du questionnaire "Vie quotidienne"

### DIFF
--- a/client/app/profil/projet_de_vie/vie_quotidienne/situation.js
+++ b/client/app/profil/projet_de_vie/vie_quotidienne/situation.js
@@ -55,12 +55,16 @@ angular.module('impactApp')
             return QuestionService.get(section, 'aideActuelle', profile);
           },
 
-          nextStep: function($state, sectionModel, question, saveCurrentState) {
+          nextStep: function($state, sectionModel, question, saveCurrentState, ProfileService, profile) {
             return function() {
               saveCurrentState();
               var answer = sectionModel[question.model];
               if (!answer) {
-                $state.go('^.fraisHandicap');
+                if (ProfileService.estAdulte(profile)) {
+                  $state.go('^.retraite');
+                } else {
+                  $state.go('^.fraisHandicap');
+                }
               } else if (answer.financiere) {
                 $state.go('^.aideFinancierePresent');
               } else if (answer.technique) {
@@ -68,7 +72,11 @@ angular.module('impactApp')
               } else if (answer.personne) {
                 $state.go('^.aidePersonne');
               } else {
-                $state.go('^.fraisHandicap');
+                if (ProfileService.estAdulte(profile)) {
+                  $state.go('^.retraite');
+                } else {
+                  $state.go('^.fraisHandicap');
+                }
               }
             };
           }


### PR DESCRIPTION
**Constat :**
La question "Êtes-vous à la retraite" s'affiche uniquement quand l'utilisateur répond à la question "Vous recevez" et lorsque l'utilisateur a plus de 20 ans.
La question « Vous percevez une ou plusieurs des aides suivantes : » s'affiche uniquement si l'utilisateur répond "Oui" à la question "Êtes-vous à la retraite".

**Attendu :**
Si l'utilisateur ne fait aucun choix à la question "Vous recevez", la question "Êtes-vous à la retraite" doit s'afficher. 
Comme l'existant, la question s'affiche uniquement si l'utilisateur a plus de 20ans.
Comme l'existant, la question « Vous percevez une ou plusieurs des aides suivantes : » s'affiche uniquement si l'utilisateur répond "Oui" à la question "Êtes-vous à la retraite".