### PR TITLE
[Lot3] n°24 ETQ Bénéficiaire : Rendre facultatifs des champs dans le questionnaire "Identité de l'autorité parentale"

### DIFF
--- a/client/components/autorite-form/autorite.html
+++ b/client/components/autorite-form/autorite.html
@@ -22,7 +22,7 @@
 
   <div class="section-row">
     <div class="address-input">
-      <div class="form-group" ng-class="{'has-error': hasError('dateDeNaissance') && forms.infoForm.$submitted, 'required': required}">
+      <div class="form-group" ng-class="{'has-error': hasError('dateDeNaissance') && forms.infoForm.$submitted}">
         <label class="control-label" for="date-de-naissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
         <input
           type="text"


### PR DESCRIPTION
Constat :
Les champs "Date de naissance", et "Complément d'adresse" sont obligatoires.

Attendu :
Ces champs doivent passer facultatifs.