### PR TITLE
[Lot3.2] n°02 ETQ Bénéficiaire : Affichages du bloc et chainage du questionnaire "Identité de l'autorité parentale"

### DIFF
--- a/client/app/profil/identites/beneficiaire.js
+++ b/client/app/profil/identites/beneficiaire.js
@@ -53,7 +53,7 @@ angular.module('impactApp')
               identite.updatedAt = Date.now();
               profile.identites.beneficiaire = identite;
               profile.$save({userId: currentUser._id}, function() {
-                if (ProfileService.estAdulte(profile)) {
+                if (profile.identites.beneficiaire.numero_secu_enfant) {
                   $state.go('^.vie_quotidienne');
                 } else {
                   $state.go('^.representant');

--- a/client/app/profil/profil.html
+++ b/client/app/profil/profil.html
@@ -60,7 +60,7 @@
           <h2>Informations obligatoires</h2>
           <ul class="profile-card-row">
             <li id="beneficiaire" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.beneficiaire" /></li>
-            <li id="autorite" class="profile-card-row-item" ng-if="!profilCtrl.estAdulte"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.autorite" /></li>
+            <li id="autorite" class="profile-card-row-item" ng-if="profilCtrl.profile.identites.beneficiaire.numero_secu_enfant"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.autorite" /></li>
             <li id="representant" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.representant" /></li>
             <li id="vieQuotidienne" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.vieQuotidienne" /></li>
             <li id="documents" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" completion="profilCtrl.documentCompletion()" options="profilCtrl.options.documents" /></li>

--- a/client/components/profile/profile.service.js
+++ b/client/components/profile/profile.service.js
@@ -69,7 +69,7 @@ angular.module('impactApp')
         return false;
       }
 
-      if (profile.identites.beneficiaire.numero_secu_enfant && profile.identites.beneficiaire.numero_secu_enfant && !profile.identites.autorite) {
+      if (profile.identites.beneficiaire && profile.identites.beneficiaire.numero_secu_enfant && !profile.identites.autorite) {
         return false;
       }
 

--- a/client/components/profile/profile.service.js
+++ b/client/components/profile/profile.service.js
@@ -69,7 +69,7 @@ angular.module('impactApp')
         return false;
       }
 
-      if (_estMineur(profile) && !profile.identites.autorite) {
+      if (profile.identites.beneficiaire.numero_secu_enfant && profile.identites.beneficiaire.numero_secu_enfant && !profile.identites.autorite) {
         return false;
       }
 


### PR DESCRIPTION
Constat :
Le questionnaire "Identité de l'autorité parentale" s'affiche si la date de naissance saisie est inférieure à 20 ans.
Cela signifie 2 choses:
- Affichage Bloc : sur la page "Profil", le bloc "Identité de l'autorité parentale" s'affiche
- Affichage du questionnaire dans le Chainage : sur le questionnaire "Identité Bénéficiaire", au clic sur le bouton "Valider", le questionnaire "Identité de l'autorité parentale" s'affiche".

Enfin sur la page profil, s'il s'affiche, le bloc "Identité de l'autorité parentale" s'affiche entre "Identité bénéficiaire" et "Vie quotidienne".

Attendu:
Pour les affichages du Bloc et du questionnaire dans le Chainage, changer ce fonctionnement par :
- Si le champ "Si c’est votre enfant qui est concerné par la demande, indiquer son numéro de sécurité sociale" a été complété, afficher le questionnaire "Identité de l'autorité parentale"
- Sinon si ce champ n'est pas complété ne pas afficher le bloc ni le questionnaire dans le Chainage.

Note A : La position du bloc "Identité de l'autorité parentale" est impactée par la carte n°07.
Note B : Cette carte est impactée par les cartes n°01 et n°26.