### PR TITLE
Mantis 6896 : ETQ usagé je souaite que la date associé a la reponse" Des indemnités journalières" du formulaire "Vie quotidienne" soit affiché correctement

### DIFF
--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -297,7 +297,7 @@
             "model": "indemnites",
             "detailUrl": "components/detail/precisez_duree.html",
             "detailModel": "duree",
-            "type": "date"
+            "detailType": "duree"
           },
           {
             "label": "Un revenu issu d'une activité en ESAT",

--- a/server/components/recapitulatif.js
+++ b/server/components/recapitulatif.js
@@ -109,6 +109,21 @@ function computeAnswers(question, trajectoireAnswers) {
         case 'date':
           answer.detail = moment(detail, moment.ISO_8601).format('DD/MM/YYYY');
           break;
+        case 'duree':
+          answer.detail = '';
+          if (detail.debut){
+            answer.detail += 'Du : ';
+            answer.detail += moment(detail.debut, moment.ISO_8601).format('DD/MM/YYYY');
+          }
+          if (detail.fin){
+            if (detail.debut){
+              answer.detail += ' au : ';
+            } else {
+              answer.detail += 'Au : ';
+            }
+            answer.detail += moment(detail.fin, moment.ISO_8601).format('DD/MM/YYYY');
+          }
+          break;
         case 'date&text':
           answer.detail = 'Date d\'entrée prévue : ';
           answer.detail += moment(detail.date, moment.ISO_8601).format('DD/MM/YYYY');


### PR DESCRIPTION
Dans le formulaire "Vie quotidienne", la complétion des champs de date associés à la réponse "Des indemnités journalières" n'est pas traduite correctement. Dans le PDF récapitulatif de la demande qui affiche : [object Object].
===> ajouter le typeDetail duree dans les pdfs