### PR TITLE
[Lot3.2_bugfix1] n°03 ETQ Bénéficiaire : Affichage du chainage du questionnaire "Identité de la personne vous aidant dans cette démarche"

### DIFF
--- a/client/app/profil/identites/autorite.js
+++ b/client/app/profil/identites/autorite.js
@@ -25,7 +25,7 @@ angular.module('impactApp')
                   profile.identites.autorite = identite;
                   profile.$save({userId: currentUser._id}, function() {
                     if (profile.identites.beneficiaire.aide === 'true') {
-                      $state.go('^.aidant');
+                      $state.go('profil.autre');
                     } else {
                       if (profile.identites.beneficiaire.protection === 'Oui') {
                         $state.go('profil.representant');

--- a/client/app/profil/identites/beneficiaire.js
+++ b/client/app/profil/identites/beneficiaire.js
@@ -60,7 +60,7 @@ angular.module('impactApp')
                   $state.go('^.autorite');
                 } else {
                   if (profile.identites.beneficiaire.aide === 'true') {
-                    $state.go('^.aidant');
+                    $state.go('profil.autre');
                   } else {
                     if (profile.identites.beneficiaire.protection === 'Oui') {
                       $state.go('^.representant');


### PR DESCRIPTION

- Si l'utilisateur a saisi "Oui" à la question "Êtes-vous aidé.e dans vos démarches auprès de la MDPH ?" dans le questionnaire "Identité bénéficiaire", alors le questionnaire "Identité de la personne vous aidant dans cette démarche" s'affiche dans le chainage.
- Si le questionnaire s'affiche dans le chainage, il s'affiche :
1) Derrière le questionnaire "Identité de l'autorité parentale" si ce dernier s'affiche.
2) Derrière "Identité bénéficiaire" si le questionnaire "Identité de l'autorité parentale" ne s'affiche pas.