### PR TITLE
[Lot3.2_bugfix01] n°10 ETQ Bénéficiaire : afficher les 5 mêmes questions avec les réponses correspondantes dans le questionnaire "Vie quotidienne"

### DIFF
--- a/client/app/profil/projet_de_vie/vie_quotidienne/situation.js
+++ b/client/app/profil/projet_de_vie/vie_quotidienne/situation.js
@@ -128,22 +128,7 @@ angular.module('impactApp')
           nextStep: function(ProfileService, profile, $state, sectionModel, saveCurrentState) {
             return function() {
               saveCurrentState();
-              if (ProfileService.estAdulte(profile)) {
-                $state.go('^.aideFinancierePasse');
-              } else {
-                var answerAideActuelle = sectionModel.aideActuelle;
-                if (answerAideActuelle.technique) {
-                  $state.go('^.aideTechnique');
-                } else if (answerAideActuelle.personne) {
-                  $state.go('^.aidePersonne');
-                } else if (sectionModel.aideActuelle.financiere) {
-                  $state.go('^.pensionInvalidite');
-                } else if (!ProfileService.estAdulte(profile)) {
-                  $state.go('^.activiteHandicap');
-                } else {
-                  $state.go('^.fraisHandicap');
-                }
-              }
+              $state.go('^.aideFinancierePasse');
             };
           }
         }

--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -398,14 +398,6 @@
           {
             "label": "Une Prestation Complémentaire de Recours à Tierce Personne",
             "model": "pcrtp"
-          },
-          {
-            "label": "Une retraite pour inaptitude dans la fonction publique ou anticipée",
-            "model": "retraiteInaptitude",
-            "detailUrl": "components/detail/precisez_date.html",
-            "detailModel": "retraiteInaptitudeDetail",
-            "detailLabel": "Depuis ?",
-            "detailType": "date"
           }
         ]
       },


### PR DESCRIPTION
**Constat:**
Les questions affichées dans le questionnaire "Vie quotidienne" s'affichent en fonction de l'âge du bénéficiaire.
Pour 5 questions, les réponses disponibles sont différentes en fonction de l'âge.

Les questions suivantes s'affichent uniquement si le bénéficiaire a 20 ans et plus :
- "Vous vivez"
- "Où vivez-vous?"
- "Dans les 12 mois précédents votre demande, avez vous perçu"
- "Vous avez besoin d'aide dans votre vie quotidienne"
- "Vous avez besoin d'aide pour votre vie sociale"

Lorsque le bénéficiaire a moins de 20 ans, il s'affiche plutôt:
- "[Prénom] vit"
- "Où vit [Prénom]?"
- "[Prénom] reçoit les aides, ressources et/ou prestations suivantes"
- "[Prénom] a besoin d'aide dans sa vie quotidienne ?"
- "[Prénom] a besoin d'aide pour sa vie sociale ?"

**Attendu:**
Pour ces 5 questions, on souhaite que toutes les réponses soient disponibles. La correction "facile" attendue par la CNSA consiste à faire ceci:

- Lorsque le bénéficiaire a moins de 20 ans, afficher les 5 mêmes questions et réponses que lorsque le bénéficiaire à 20 ans et plus.

- Ces champs et les données saisies doivent apparaitre dans le PDF CERFA.