### PR TITLE
[Lot3.2_bugfix02] n°04 ETQ Bénéficiaire : Affichage du chainage du questionnaire "Identité du représentant légal"

### DIFF
--- a/client/app/profil/aidant/aidant.js
+++ b/client/app/profil/aidant/aidant.js
@@ -29,11 +29,7 @@ angular.module('impactApp')
           saveSection: function($state, currentUser, profile, sectionId, sectionModel) {
             return function() {
               profile.saveSection(sectionId, sectionModel, currentUser, function() {
-                if (profile.identites.beneficiaire.protection === 'Oui') {
-                  $state.go('profil.representant');
-                } else {
-                  $state.go('profil.situations_particulieres');
-                }
+                $state.go('profil', {}, {reload: true});
               });
             };
           }

--- a/client/app/profil/identites/autorite.js
+++ b/client/app/profil/identites/autorite.js
@@ -25,9 +25,9 @@ angular.module('impactApp')
                   profile.identites.autorite = identite;
                   profile.$save({userId: currentUser._id}, function() {
                     if (profile.identites.beneficiaire.aide === 'true') {
-                      $state.go('^.aidant');
+                      $state.go('profil.autre');
                     } else {
-                      if (profile.identites.beneficiaire.protection === 'Oui') {
+                      if (profile.identites.beneficiaire.protection === 'true') {
                         $state.go('profil.representant');
                       } else {
                         $state.go('profil.situations_particulieres');

--- a/client/app/profil/identites/autre.js
+++ b/client/app/profil/identites/autre.js
@@ -36,7 +36,11 @@ angular.module('impactApp')
               identite.updatedAt = Date.now();
               profile.identites.autre = identite;
               profile.$save({userId: currentUser._id}, function() {
-                $state.go('^', {}, {reload: true});
+                if (profile.identites.beneficiaire.protection === 'true') {
+                  $state.go('profil.representant');
+                } else {
+                  $state.go('profil.situations_particulieres');
+                }
               });
             }
           };

--- a/client/app/profil/identites/beneficiaire.js
+++ b/client/app/profil/identites/beneficiaire.js
@@ -60,9 +60,9 @@ angular.module('impactApp')
                   $state.go('^.autorite');
                 } else {
                   if (profile.identites.beneficiaire.aide === 'true') {
-                    $state.go('^.aidant');
+                    $state.go('profil.autre');
                   } else {
-                    if (profile.identites.beneficiaire.protection === 'Oui') {
+                    if (profile.identites.beneficiaire.protection === 'true') {
                       $state.go('^.representant');
                     } else {
                       $state.go('profil.situations_particulieres');


### PR DESCRIPTION
constat :
si on saisiOui à la question « Bénéficiez-vous d’une mesure de protection ? » et non à la question "êtes-vous aidé.e dans vos démarches..." dans le questionnaire "Identité bénéficiaire"
alors on obtient le chaînage "identité de l'autorité parentale" --> "situations particulières" --> "Vie quotidienne"

--> Il manque le questionnaire "Identité du représentant légal"