### PR TITLE
[Lot3.2_bugfix01] n°01 ETQ Bénéficiaire : Questionnaire "Identité bénéficiaire": évol champ "sécurité sociale"

### DIFF
--- a/client/app/profil/identites/beneficiaire.html
+++ b/client/app/profil/identites/beneficiaire.html
@@ -259,7 +259,7 @@
       </div>
     </div>
 
-    <div class="form-group" ng-class="{'required': estEnfant, 'has-error': infoForm.numero_secu_enfant.$invalid && infoForm.$submitted}" ng-if="!estAdulteStricte">
+    <div class="form-group" ng-class="{'required': estEnfant, 'has-error': infoForm.numero_secu_enfant.$invalid && infoForm.$submitted}" ng-if="!estAdulte">
       <label for="numero_secu_enfant" class="control-label">Si c’est votre enfant qui est concerné par la demande, indiquer son numéro de sécurité sociale</label>
       <input id="numero_secu_enfant" type="text" name="numero_secu_enfant" class="form-control" ng-required="estEnfant"
         ng-model="identite.numero_secu_enfant" ui-options="maskOptions" ui-mask="* ** ** ** *** *** **" numero-secu>

--- a/client/app/profil/identites/beneficiaire.js
+++ b/client/app/profil/identites/beneficiaire.js
@@ -29,13 +29,13 @@ angular.module('impactApp')
           $scope.getAdress = AdressService.getAdress;
           $scope.fillAdressOnSelect = AdressService.fillAdressOnSelect;
           $scope.maskOptions = {clearOnBlur: false, allowInvalidValue: true};
-          $scope.estAdulteStricte = ProfileService.estAdulteStricte(profile);
+          $scope.estAdulte = ProfileService.estAdulte(profile);
           $scope.estEnfant = ProfileService.estEnfant(profile);
 
           $scope.majAdulteEnfant = function() {
-            $scope.estAdulteStricte = ProfileService.estAdulteStricte(profile);
+            $scope.estAdulte = ProfileService.estAdulte(profile);
             $scope.estEnfant = ProfileService.estEnfant(profile);
-            if ($scope.estAdulteStricte) {
+            if ($scope.estAdulte) {
               identite.numero_secu_enfant = '';
             }
           };

--- a/client/components/date-service/date.service.js
+++ b/client/components/date-service/date.service.js
@@ -4,7 +4,7 @@ angular.module('impactApp')
   .factory('estAdulteStricte', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().diff(dateNaissance, 'years') > 20;
+        return moment().add(-20, 'years').diff(dateNaissance, 'days') > 0;
       }
 
       return true;

--- a/client/components/date-service/date.service.js
+++ b/client/components/date-service/date.service.js
@@ -4,7 +4,7 @@ angular.module('impactApp')
   .factory('estEnfant', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().add(-16, 'years').diff(dateNaissance, 'days') < 0;
+        return moment().add(-16, 'years').diff(dateNaissance, 'hours') < 0;
       }
 
       return false;
@@ -13,7 +13,7 @@ angular.module('impactApp')
   .factory('estAdulte', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().add(-20, 'years').diff(dateNaissance, 'days') >= 0;
+        return moment().add(-20, 'years').diff(dateNaissance, 'hours') >= 0;
       }
 
       return true;
@@ -22,7 +22,7 @@ angular.module('impactApp')
   .factory('estMineur', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().add(-20, 'years').diff(dateNaissance, 'days') < 0;
+        return moment().add(-20, 'years').diff(dateNaissance, 'hours') < 0;
       }
 
       return false;

--- a/client/components/date-service/date.service.js
+++ b/client/components/date-service/date.service.js
@@ -1,19 +1,10 @@
 'use strict';
 
 angular.module('impactApp')
-  .factory('estAdulteStricte', function() {
-    return function(dateNaissance) {
-      if (dateNaissance) {
-        return moment().add(-20, 'years').diff(dateNaissance, 'days') > 0;
-      }
-
-      return true;
-    };
-  })
   .factory('estEnfant', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().diff(dateNaissance, 'years') < 16;
+        return moment().add(-16, 'years').diff(dateNaissance, 'days') < 0;
       }
 
       return false;
@@ -22,7 +13,7 @@ angular.module('impactApp')
   .factory('estAdulte', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().diff(dateNaissance, 'years') >= 20;
+        return moment().add(-20, 'years').diff(dateNaissance, 'days') >= 0;
       }
 
       return true;
@@ -31,7 +22,7 @@ angular.module('impactApp')
   .factory('estMineur', function() {
     return function(dateNaissance) {
       if (dateNaissance) {
-        return moment().diff(dateNaissance, 'years') < 20;
+        return moment().add(-20, 'years').diff(dateNaissance, 'days') < 0;
       }
 
       return false;

--- a/client/components/profile/profile.service.js
+++ b/client/components/profile/profile.service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('impactApp')
-.factory('ProfileService', function ProfileService(estAdulte, estMineur, estAdulteStricte, estEnfant, RequestService) {
+.factory('ProfileService', function ProfileService(estAdulte, estMineur, estEnfant, RequestService) {
     function _estMineur(profile) {
       if (profile.identites && profile.identites.beneficiaire) {
         return estMineur(profile.identites.beneficiaire.dateNaissance);
@@ -23,14 +23,6 @@ angular.module('impactApp')
         return estEnfant(profile.identites.beneficiaire.dateNaissance);
       } else {
         return false;
-      }
-    }
-
-    function _estAdulteStricte(profile) {
-      if (profile && profile.identites && profile.identites.beneficiaire.dateNaissance) {
-        return estAdulteStricte(profile.identites.beneficiaire.dateNaissance);
-      } else {
-        return true;
       }
     }
 
@@ -117,7 +109,6 @@ angular.module('impactApp')
 
       estAdulte: _estAdulte,
       estMineur: _estMineur,
-      estAdulteStricte: _estAdulteStricte,
       estEnfant: _estEnfant,
       getCompletion,
       getMissingSection,


### PR DESCRIPTION
Constat :
le champ "Si c’est votre enfant qui est concerné par la demande, indiquer son numéro de sécurité sociale" est facultatif

Attendu :
pour le champ "Si c’est votre enfant qui est concerné par la demande, indiquer son numéro de sécurité sociale":

Si la date de naissance est < 16 ans, le champ s'affiche et est obligatoire. Au clic sur le bouton "Valider", si le champ est vide, un message d'erreur doit s'afficher.

Si la date de naissance est 16 ans ≤ âge < 20 ans, le champ s'affiche est facultatif

Si la date de naissance est >= 20 ans, le champ ne s'affiche pas