### PR TITLE
[Lot3.2_bugfix01] n°24 ETQ Bénéficiaire : Rendre facultatifs des champs dans le questionnaire "Identité de l'autorité parentale"

### DIFF
--- a/client/components/autorite-form/autorite.html
+++ b/client/components/autorite-form/autorite.html
@@ -20,29 +20,6 @@
     </div>
   </div>
 
-  <div class="section-row">
-    <div class="address-input">
-      <div class="form-group" ng-class="{'has-error': hasError('dateDeNaissance') && forms.infoForm.$submitted}">
-        <label class="control-label" for="date-de-naissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
-        <input
-          type="text"
-          class="form-control"
-          name="dateDeNaissance{{id}}"
-          id="date-de-naissance{{id}}"
-          ng-required="{{required}}"
-          ng-model="identite.dateNaissance"
-          input-date
-          date-autocomplete
-          placeholder="JJ/MM/AAAA"
-          aria-describedby="help-date-de-naissance">
-        <div ng-messages="infoForm.dateDeNaissance.$error" ng-if="infoForm.$submitted">
-          <p class="help-block" id="help-date-de-naissance" ng-message='inputDate'>Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
-          <p class="help-block" id="help-date-de-naissance" ng-message='required'>Ce champ est obligatoire.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="form-group">
     <div class="checkbox">
       <label>
@@ -56,7 +33,7 @@
 <section class="identite-section">
 
   <div class="section-row">
-    <div class="form-group" ng-class="{'has-error': hasError('dateDeNaissance') && forms.infoForm.$submitted">
+    <div class="form-group">
       <label class="control-label" for="date-de-naissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
       <input
         type="text"


### PR DESCRIPTION
Constat : 
Le bouton "Valider" du formulaire "Identité de l'autorité parentale" est vert mais ne fonctionne pas au clic, tant que la date de naissance n'a pas été remplie.
Attendu : 
Même si la date de naissance n'est pas renseignée (car non obligatoire), le clic sur "Valider" fonctionne (enregistrement+page suivante)