### PR TITLE
[Lot 3.2] Bug intra-version : Il y a 2 champs date de naissance pour l'autorité parentale

### DIFF
--- a/client/app/profil/profil.html
+++ b/client/app/profil/profil.html
@@ -61,7 +61,7 @@
           <ul class="profile-card-row">
             <li id="beneficiaire" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.beneficiaire" /></li>
             <li id="autorite" class="profile-card-row-item" ng-if="profilCtrl.profile.identites.beneficiaire.numero_secu_enfant"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.autorite" /></li>
-            <li id="representant" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.representant" /></li>
+            <li id="representant" class="profile-card-row-item" ng-if="profilCtrl.profile.identites.beneficiaire.protection === 'true' "><profile-category profile="profilCtrl.profile" options="profilCtrl.options.representant" /></li>
             <li id="vieQuotidienne" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.vieQuotidienne" /></li>
             <li id="documents" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" completion="profilCtrl.documentCompletion()" options="profilCtrl.options.documents" /></li>
             <li id="unconfirmed" ng-if="profilCtrl.currentUser.unconfirmed" class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.unconfirmed" /></li>
@@ -74,8 +74,8 @@
           <ul class="profile-card-row">
             <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.vieScolaire" /></li>
             <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.vieTravail" /></li>
-            <li class="profile-card-row-item" ng-if="profilCtrl.profile.identites.beneficiaire.aide  === 'true' "><profile-category profile="profilCtrl.profile" options="profilCtrl.options.aidant" ></li>
-            <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.autre" /></li>
+            <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.aidant" ></li>
+            <li class="profile-card-row-item" ng-if="profilCtrl.profile.identites.beneficiaire.aide  === 'true' "><profile-category profile="profilCtrl.profile" options="profilCtrl.options.autre" /></li>
             <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" completion="profilCtrl.prestationsCompletion()" options="profilCtrl.options.prestations" /></li>
             <li class="profile-card-row-item"><profile-category profile="profilCtrl.profile" options="profilCtrl.options.particulieres" /></li>
           </ul>


### PR DESCRIPTION
Constat:
Le bloc "Représentant légal" est affiché sans conditions (dans tous les cas).
IL est obligatoire à la validation de la demande.
Attendu:
Son affichage doit être conditionné par la question "Bénéficiez-vous d'une mesure de protection ?" du formulaire "Identité bénéficiaire"