### PR TITLE
Mantis 6957 & 6958 : Mantis 6957 : ETQ usagé je souhaiterais avoir le message "Votre compte a bien été validé" lorsque je clique sur le lien du mail de confirmation de compte et que mon compte est déjà activé.                                   & Mantis 6958 : ETQ usagé je souhaiterais que le bloc "Confirmer votre compte mail" ne soit plus visible après avoir validé mon compte

### DIFF
--- a/client/app/account/confirmer_mail/confirmer_mail.controller.js
+++ b/client/app/account/confirmer_mail/confirmer_mail.controller.js
@@ -6,9 +6,6 @@ angular.module('impactApp')
     $http.post('/api/users/' + $stateParams.userId + '/confirmer_mail/' + $stateParams.newMailToken).then(function() {
       $scope.pending = false;
       currentUser.unconfirmed = false;
-      /*$interval(function() {
-        $state.go('login');
-      }, 10000, 1);*/
     }).catch(function() {
       $scope.pending = false;
       $scope.error = true;

--- a/client/app/account/confirmer_mail/confirmer_mail.controller.js
+++ b/client/app/account/confirmer_mail/confirmer_mail.controller.js
@@ -2,10 +2,11 @@
 
 angular.module('impactApp')
   .controller('ConfirmerMailCtrl', function($scope, $state, $interval, $stateParams, $http, currentUser) {
-    $scope.pending = true;
     $http.post('/api/users/' + $stateParams.userId + '/confirmer_mail/' + $stateParams.newMailToken).then(function() {
       currentUser.unconfirmed = false;
-    }).catch(function() {
-      $scope.error = true;
+    }).catch(function(res) {
+      if (res.status !== undefined) {
+        $scope.error = true;
+      }
     });
   });

--- a/client/app/account/confirmer_mail/confirmer_mail.controller.js
+++ b/client/app/account/confirmer_mail/confirmer_mail.controller.js
@@ -4,10 +4,8 @@ angular.module('impactApp')
   .controller('ConfirmerMailCtrl', function($scope, $state, $interval, $stateParams, $http, currentUser) {
     $scope.pending = true;
     $http.post('/api/users/' + $stateParams.userId + '/confirmer_mail/' + $stateParams.newMailToken).then(function() {
-      $scope.pending = false;
       currentUser.unconfirmed = false;
     }).catch(function() {
-      $scope.pending = false;
       $scope.error = true;
     });
   });

--- a/client/app/account/confirmer_mail/confirmer_mail.controller.js
+++ b/client/app/account/confirmer_mail/confirmer_mail.controller.js
@@ -1,14 +1,15 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('ConfirmerMailCtrl', function($scope, $state, $interval, $stateParams, $http) {
+  .controller('ConfirmerMailCtrl', function($scope, $state, $interval, $stateParams, $http, currentUser) {
     $scope.pending = true;
-    $http.post('/api/users/' + $stateParams.userId + '/confirmer_mail/' + $stateParams.newMailToken).success(function() {
+    $http.post('/api/users/' + $stateParams.userId + '/confirmer_mail/' + $stateParams.newMailToken).then(function() {
       $scope.pending = false;
-      $interval(function() {
+      currentUser.unconfirmed = false;
+      /*$interval(function() {
         $state.go('login');
-      }, 5000, 1);
-    }).error(function() {
+      }, 10000, 1);*/
+    }).catch(function() {
       $scope.pending = false;
       $scope.error = true;
     });

--- a/client/app/account/confirmer_mail/confirmer_mail.html
+++ b/client/app/account/confirmer_mail/confirmer_mail.html
@@ -6,8 +6,7 @@
       </div>
       <div class="pending" ng-if="!pending">
         <div ng-if="!error">
-          <h1>Adresse mail confirmée</h1>
-          <h2><small>Vous pouvez désormais vous connecter avec votre compte.</small></h2>
+          <h2>Votre compte a bien été validé</h2>
         </div>
         <div ng-if="error">
           <h1><i class="fa fa-warning"></i> Erreur</h1>

--- a/client/app/account/confirmer_mail/confirmer_mail.html
+++ b/client/app/account/confirmer_mail/confirmer_mail.html
@@ -1,10 +1,6 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-sm-12">
-      <div class="pending" ng-if="pending">
-         <h2><small><i class="fa fa-spinner fa-pulse"></i> En attente de confirmation ...</small></h2>
-      </div>
-      <div class="pending" ng-if="!pending">
         <div ng-if="!error">
           <h2>Votre compte a bien été validé</h2>
         </div>
@@ -12,7 +8,6 @@
           <h1><i class="fa fa-warning"></i> Erreur</h1>
           <h2><small>Ce lien est incorrect ou à déjà été utilisé.</small></h2>
         </div>
-      </div>
     </div>
   </div>
 </div>

--- a/client/app/account/confirmer_mail/confirmer_mail.html
+++ b/client/app/account/confirmer_mail/confirmer_mail.html
@@ -1,24 +1,13 @@
-<div class="section-body">
-  <div class="section-body-head">
-    <h2>
-      <a id="backtoprofile" ui-sref="profil({profileId: profilCtrl.profile._id})">Profil</a>
-      / Confirmer votre compte mail
-    </h2>
-  </div>
-
-  <div class="section-body-content">
-    <div class="section-body-content-text">
-      <div ng-if="!error">
-        <h2>Votre compte a bien été validé</h2>
-      </div>
-      <div ng-if="error">
-        <h1><i class="fa fa-warning"></i> Erreur</h1>
-        <h2><small>Ce lien est incorrect ou à déjà été utilisé.</small></h2>
-      </div>
-    </div>
-
-    <div class="text-right">
-      <a ui-sref="^" class="btn btn-link" role="button">Retourner au profil</a>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-lg-offset-2 col-sm-12">
+        <div ng-if="!error">
+          <h2>Votre compte a bien été validé</h2>
+        </div>
+        <div ng-if="error">
+          <h1><i class="fa fa-warning"></i> Erreur</h1>
+          <h2><small>Ce lien est incorrect ou à déjà été utilisé.</small></h2>
+        </div>
     </div>
   </div>
 </div>

--- a/client/app/account/confirmer_mail/confirmer_mail.html
+++ b/client/app/account/confirmer_mail/confirmer_mail.html
@@ -1,13 +1,24 @@
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 col-lg-offset-2 col-sm-12">
-        <div ng-if="!error">
-          <h2>Votre compte a bien été validé</h2>
-        </div>
-        <div ng-if="error">
-          <h1><i class="fa fa-warning"></i> Erreur</h1>
-          <h2><small>Ce lien est incorrect ou à déjà été utilisé.</small></h2>
-        </div>
+<div class="section-body">
+  <div class="section-body-head">
+    <h2>
+      <a id="backtoprofile" ui-sref="profil({profileId: profilCtrl.profile._id})">Profil</a>
+      / Confirmer votre compte mail
+    </h2>
+  </div>
+
+  <div class="section-body-content">
+    <div class="section-body-content-text">
+      <div ng-if="!error">
+        <h2>Votre compte a bien été validé</h2>
+      </div>
+      <div ng-if="error">
+        <h1><i class="fa fa-warning"></i> Erreur</h1>
+        <h2><small>Ce lien est incorrect ou à déjà été utilisé.</small></h2>
+      </div>
+    </div>
+
+    <div class="text-right">
+      <a ui-sref="^" class="btn btn-link" role="button">Retourner au profil</a>
     </div>
   </div>
 </div>

--- a/client/app/profil/unconfirmed/unconfirmed.html
+++ b/client/app/profil/unconfirmed/unconfirmed.html
@@ -17,7 +17,7 @@
     </div>
 
     <div class="text-right">
-      <a ui-sref="^" class="btn btn-link" role="button">Retourner au profil</a>
+      <a ui-sref="^" class="btn btn-lg btn-primary" role="button">Retourner au profil</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Lorsque l'usager souhaite valider son compte, il reçoit un mail contenant un lien sur lequel il faut cliquer pour effectivement valider le compte.
Ce lien mène l'usager à une page blanche. Il faudrait que cette page indique que le compte a bel et bien été validé.

Pourriez-vous ajouter le message suivant :
- "Votre compte a bien été validé"
au même format que sur la page indiquant "Un mail de confirmation à bien été renvoyé sur votre compte mail" lors du premier clic sur le bloc "Confirmer votre compte mail".