### PR TITLE
[Lot3.2_bugfix01] Mantis 6896 : ETQ usagé je souaite que la date associé a la reponse" Des indemnités journalières" du formulaire "Vie quotidienne" soit affiché correctement

### DIFF
--- a/server/components/recapitulatif.js
+++ b/server/components/recapitulatif.js
@@ -112,14 +112,14 @@ function computeAnswers(question, trajectoireAnswers) {
         case 'duree':
           answer.detail = '';
           if (detail.debut){
-            answer.detail += 'Du : ';
+            answer.detail += 'Du ';
             answer.detail += moment(detail.debut, moment.ISO_8601).format('DD/MM/YYYY');
           }
           if (detail.fin){
             if (detail.debut){
-              answer.detail += ' au : ';
+              answer.detail += ' au ';
             } else {
-              answer.detail += 'Au : ';
+              answer.detail += 'Au ';
             }
             answer.detail += moment(detail.fin, moment.ISO_8601).format('DD/MM/YYYY');
           }


### PR DESCRIPTION
Constat : 
Affichage PDF : "Du : 07/07/201 au : 08/08/2012"
Attendu : 
pour le CERFA, il serait plus "joli" d'enlever les ":", c'est à dire "Du 
=>enlever : avant du et au dans le pdf