### PR TITLE
[Lot3.2_bugfix03] n°26 ETQ Bénéficiaire : Création du bloc et du questionnaire "Identité du représentant légal"

### DIFF
--- a/client/app/profil/identites/representants.html
+++ b/client/app/profil/identites/representants.html
@@ -8,10 +8,10 @@
 
   <div class="row">
     <div class="col-sm-6">
-      <representant-form representant="representant.representant1" id="1" current-mdph="currentMdph" required="true"></representant-form>
+      <representant-form representant="representant.representant1" libelle="Représentant légal 1" id="1" current-mdph="currentMdph" required="true"></representant-form>
     </div>
     <div class="col-sm-6">
-      <representant-form representant="representant.representant2" id="2" current-mdph="currentMdph" required="false"></representant-form>
+      <representant-form representant="representant.representant2" libelle="Représentant légal 2 (le cas échéant)" id="2" current-mdph="currentMdph" required="false"></representant-form>
     </div>
   </div>
 

--- a/client/components/representant-form/representant.component.js
+++ b/client/components/representant-form/representant.component.js
@@ -6,6 +6,7 @@ angular.module('impactApp').component('representantForm', {
   controllerAs: 'representantctrl',
   bindings: {
     representant: '=',
+    libelle: '@',
     id: '<',
     required: '<',
     currentMdph: '<',

--- a/client/components/representant-form/representant.controller.js
+++ b/client/components/representant-form/representant.controller.js
@@ -4,6 +4,7 @@ angular.module('impactApp')
   .controller('RepresentantCtrl', function($state, $scope, AdressService) {
       $scope.representant = this.representant;
       $scope.id = this.id;
+      $scope.libelle = this.libelle;
       $scope.required = this.required;
       $scope.currentMdph = this.currentMdph;
       $scope.getAdress = AdressService.getAdress;

--- a/client/components/representant-form/representant.html
+++ b/client/components/representant-form/representant.html
@@ -1,4 +1,4 @@
-<h3>Représentant légal {{id}}</h3>
+<h3>{{libelle}}</h3>
 <section class="identite-section">
   <div class="section-row">
       <div class="form-group"

--- a/server/components/recapitulatif.js
+++ b/server/components/recapitulatif.js
@@ -229,6 +229,20 @@ export default function({request, host, mdph}, next) {
         request.formAnswers.identites.autorite.parent2.localite = request.formAnswers.identites.beneficiaire.localite;
         request.formAnswers.identites.autorite.parent2.pays = request.formAnswers.identites.beneficiaire.pays;
       }
+      if(request.formAnswers.identites && request.formAnswers.identites.representant && request.formAnswers.identites.representant.representant1 && request.formAnswers.identites.representant.representant1.isSameAddress){
+        request.formAnswers.identites.representant.representant1.complement_adresse = request.formAnswers.identites.beneficiaire.complement_adresse;
+        request.formAnswers.identites.representant.representant1.nomVoie = request.formAnswers.identites.beneficiaire.nomVoie;
+        request.formAnswers.identites.representant.representant1.code_postal = request.formAnswers.identites.beneficiaire.code_postal;
+        request.formAnswers.identites.representant.representant1.localite = request.formAnswers.identites.beneficiaire.localite;
+        request.formAnswers.identites.representant.representant1.pays = request.formAnswers.identites.beneficiaire.pays;
+      }
+      if(request.formAnswers.identites && request.formAnswers.identites.representant && request.formAnswers.identites.representant.representant2 && request.formAnswers.identites.representant.representant2.isSameAddress){
+        request.formAnswers.identites.representant.representant2.complement_adresse = request.formAnswers.identites.beneficiaire.complement_adresse;
+        request.formAnswers.identites.representant.representant2.nomVoie = request.formAnswers.identites.beneficiaire.nomVoie;
+        request.formAnswers.identites.representant.representant2.code_postal = request.formAnswers.identites.beneficiaire.code_postal;
+        request.formAnswers.identites.representant.representant2.localite = request.formAnswers.identites.beneficiaire.localite;
+        request.formAnswers.identites.representant.representant2.pays = request.formAnswers.identites.beneficiaire.pays;
+      }
       callback(null, request.formAnswers.identites);
     },
 


### PR DESCRIPTION
Suite à une anomalie remontée via Mantis #6959, la case à cocher 'Même adresse que le bénéficiaire' induit une répercussion de l'adresse dans le PDF CERFA, tel qui décrit dans la carte liée #6959,
KO pour "Représentant légal 2 (le cas échéant)"
constaté : "Représentant légal 2"
attendu : "Représentant légal 2 (le cas échéant)" 
=>
reseigner l'adresse des representants dans le cas ou même adresse choisie et changer le libellé de la colonne pour le deuxieme représentant légal