### PR TITLE
[Lot3.2_bugfix04] n°03 ETQ Bénéficiaire : afficher en rouge les blocs « Autorité parentale » et « représentant légal»; en gris le bloc « Personne vous aidant dans cette démarche obligatoire »  s'ils ne sont pas renseignés 

### DIFF
--- a/client/app/profil/profil.controller.js
+++ b/client/app/profil/profil.controller.js
@@ -21,6 +21,7 @@ angular.module('impactApp').controller('ProfilCtrl', function(
   this.estAdulte = ProfileService.estAdulte(profile);
   this.identiteAidantObligatoire = ProfileService.identiteAidantObligatoire(profile);
   this.representantObligatoire = ProfileService.representantObligatoire(profile);
+  this.autoriteObligatoire = ProfileService.autoriteObligatoire(profile);
 
   if (currentUser.unconfirmed === true) {
     User.get(currentUser._id).$promise
@@ -67,7 +68,7 @@ angular.module('impactApp').controller('ProfilCtrl', function(
       title: 'Autorité parentale',
       icon: 'fa-users',
       model: 'identites.autorite',
-      mandatory: !this.estAdulte,
+      mandatory: this.autoriteObligatoire,
       action: {
         sref: 'profil.autorite'
       }

--- a/client/app/profil/profil.controller.js
+++ b/client/app/profil/profil.controller.js
@@ -19,7 +19,6 @@ angular.module('impactApp').controller('ProfilCtrl', function(
   this.prestationsCompletion = () => RequestService.getPrestationCompletion(currentRequest) ? 'complete' : null;
   this.documentCompletion = () => RequestService.getDocumentCompletion(currentRequest) ? 'complete' : 'error';
   this.estAdulte = ProfileService.estAdulte(profile);
-  this.identiteAidantObligatoire = ProfileService.identiteAidantObligatoire(profile);
   this.representantObligatoire = ProfileService.representantObligatoire(profile);
   this.autoriteObligatoire = ProfileService.autoriteObligatoire(profile);
 
@@ -87,7 +86,6 @@ angular.module('impactApp').controller('ProfilCtrl', function(
     autre: {
       title: 'Personne vous aidant dans cette démarche',
       model: 'identites.autre',
-      mandatory: this.identiteAidantObligatoire,
       icon: 'fa-users',
       action: {
         sref: 'profil.autre'

--- a/client/components/profile/profile-category.component.js
+++ b/client/components/profile/profile-category.component.js
@@ -40,9 +40,7 @@ const profileCategoryComponent = {
     }
 
     computeMandatory(model, ProfileService) {
-      if (model === 'identites.autre') {
-        return ProfileService.identiteAidantObligatoire(this.profile);
-      } else if (model === 'identites.representant') {
+      if (model === 'identites.representant') {
         return ProfileService.representantObligatoire(this.profile);
       } else if (model === 'identites.autorite') {
         return ProfileService.autoriteObligatoire(this.profile);

--- a/client/components/profile/profile-category.component.js
+++ b/client/components/profile/profile-category.component.js
@@ -11,7 +11,7 @@ const profileCategoryComponent = {
   templateUrl: 'components/profile/profile-category.html',
   controllerAs: 'profileCategoryCtrl',
   controller: class profileCategoryController {
-    constructor($state) {
+    constructor($state, ProfileService) {
       const { title, subhead, content, icon, model, action } = this.options;
 
       this.$state = $state;
@@ -22,13 +22,8 @@ const profileCategoryComponent = {
       this.action = action;
 
       this.section = _.property(model)(this.profile);
-
-      this.mandatory =  this.options.mandatory;
-      if (model === 'identites.autre' && this.profile.identites && this.profile.identites.beneficiaire) {
-        this.mandatory = this.profile.identites.beneficiaire.aide === 'true';
-      }
-
       this.updatedAt = this.section && this.section.updatedAt;
+      this.mandatory = this.computeMandatory(model, ProfileService);
       this.completion = this.completion || this.computeCompletion();
     }
 
@@ -44,9 +39,21 @@ const profileCategoryComponent = {
       }
     }
 
+    computeMandatory(model, ProfileService) {
+      if (model === 'identites.autre') {
+        return ProfileService.identiteAidantObligatoire(this.profile);
+      } else if (model === 'identites.representant') {
+        return ProfileService.representantObligatoire(this.profile);
+      } else if (model === 'identites.autorite') {
+        return ProfileService.autoriteObligatoire(this.profile);
+      } else {
+        return this.options.mandatory;
+      }
+    }
+
     static get $inject() {
       return [
-        '$state'
+        '$state', 'ProfileService'
       ];
     }
   }

--- a/client/components/profile/profile.service.js
+++ b/client/components/profile/profile.service.js
@@ -26,10 +26,6 @@ angular.module('impactApp')
       }
     }
 
-    function identiteAidantObligatoire(profile) {
-      return profile.identites && profile.identites.beneficiaire && profile.identites.beneficiaire.aide === 'true';
-    }
-
     function representantObligatoire(profile) {
       return profile.identites && profile.identites.beneficiaire && profile.identites.beneficiaire.protection === 'true';
     }
@@ -40,10 +36,6 @@ angular.module('impactApp')
 
     function getMissingSection(profile, request, user) {
       const missingSections = [];
-
-      if (identiteAidantObligatoire(profile) && !profile.identites.autre) {
-        missingSections.push('autre');
-      }
 
       if (user.unconfirmed) {
         missingSections.push('unconfirmed');
@@ -89,10 +81,6 @@ angular.module('impactApp')
         return false;
       }
 
-      if (identiteAidantObligatoire(profile) && !profile.identites.autre) {
-        return false;
-      }
-
       return true;
     }
 
@@ -134,7 +122,6 @@ angular.module('impactApp')
       getMissingSection,
       needUploadCV,
       getAskedDocumentTypes,
-      identiteAidantObligatoire,
       representantObligatoire,
       autoriteObligatoire
     };

--- a/client/components/profile/profile.service.js
+++ b/client/components/profile/profile.service.js
@@ -135,6 +135,7 @@ angular.module('impactApp')
       needUploadCV,
       getAskedDocumentTypes,
       identiteAidantObligatoire,
-      representantObligatoire
+      representantObligatoire,
+      autoriteObligatoire
     };
   });


### PR DESCRIPTION
Bloc « Personne vous aidant dans cette démarche obligatoire » => le rendre facultatif
Blocs « Autorité parentale » et « Personne vous aidant dans cette démarche » s'affichent comme non obligatoires (grisés) lorsque l’on ne les a pas validés et que l'on est sorti du chainage, l'afficher obligatoire.