### PR TITLE
[Lot3.2_bugfix02] n°24 & 26 : Élargir les champs "Date de naissance"  et afficher "Pays" dans la même ligne avec code postal et localité dans les écrans autorité parental et représentant légal 

### DIFF
--- a/client/components/autorite-form/autorite.html
+++ b/client/components/autorite-form/autorite.html
@@ -32,23 +32,21 @@
 
 <section class="identite-section">
 
-  <div class="section-row">
-    <div class="address-input">
-      <div class="form-group" ng-class="{'has-error': forms.infoForm.dateDeNaissance{{id}}.$invalid && forms.infoForm.$submitted}">
-        <label class="control-label" for="dateDeNaissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
-        <input
-          type="text"
-          class="form-control"
-          name="dateDeNaissance{{id}}"
-          id="dateDeNaissance{{id}}"
-          ng-model="identite.dateNaissance"
-          input-date
-          date-autocomplete
-          placeholder="JJ/MM/AAAA"
-          aria-describedby="help-date-de-naissance">
-        <div ng-messages="getError('dateDeNaissance')" ng-if="forms.infoForm.$submitted">
-          <p class="help-block" id="help-date-de-naissance" ng-message='inputDate'>Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
-        </div>
+  <div class="address-input">
+    <div class="form-group" ng-class="{'has-error': forms.infoForm.dateDeNaissance{{id}}.$invalid && forms.infoForm.$submitted}">
+      <label class="control-label" for="dateDeNaissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
+      <input
+        type="text"
+        class="form-control"
+        name="dateDeNaissance{{id}}"
+        id="dateDeNaissance{{id}}"
+        ng-model="identite.dateNaissance"
+        input-date
+        date-autocomplete
+        placeholder="JJ/MM/AAAA"
+        aria-describedby="help-date-de-naissance">
+      <div ng-messages="getError('dateDeNaissance')" ng-if="forms.infoForm.$submitted">
+        <p class="help-block" id="help-date-de-naissance" ng-message='inputDate'>Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
       </div>
     </div>
   </div>
@@ -104,16 +102,13 @@
           ng-model="identite.code_postal">
         </div>
       </div>
-      <div class="col-md-8">
+      <div class="col-md-4">
         <div class="form-group">
           <label for="localite{{id}}" class="control-label">Localité</label>
           <input id="localite{{id}}" type="text" name="localite{{id}}" class="form-control" ng-model="identite.localite">
         </div>
       </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <div class="form-group">
           <label for="pays{{id}}" class="control-label">Pays</label>
           <input id="pays{{id}}" type="text" name="pays{{id}}" class="form-control" ng-model="identite.pays">

--- a/client/components/representant-form/representant.html
+++ b/client/components/representant-form/representant.html
@@ -28,27 +28,27 @@
 </section>
 
 <section class="identite-section">
-    <div class="section-row">
-      <div class="address-input">
-        <div class="form-group" ng-class="{'has-error': forms.representantForm.dateDeNaissance{{id}}.$invalid && forms.representantForm.$submitted}">
-          <label class="control-label" for="date-de-naissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
-          <input
-            type="text"
-            class="form-control"
-            name="dateDeNaissance{{id}}"
-            id="dateDeNaissance{{id}}"
-            ng-model="representant.dateNaissance"
-            input-date
-            date-autocomplete
-            placeholder="JJ/MM/AAAA"
-            aria-describedby="help-date-de-naissance">
-          <div ng-messages="getError('dateDeNaissance')" ng-if="forms.representantForm.$submitted">
-            <p class="help-block" id="help-date-de-naissance" ng-message='inputDate'>Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
-          </div>
-        </div>
+
+  <div class="address-input">
+    <div class="form-group" ng-class="{'has-error': forms.representantForm.dateDeNaissance{{id}}.$invalid && forms.representantForm.$submitted}">
+      <label class="control-label" for="date-de-naissance{{id}}">Date de naissance <span class="small">au format jour/mois/année</span></label>
+      <input
+        type="text"
+        class="form-control"
+        name="dateDeNaissance{{id}}"
+        id="dateDeNaissance{{id}}"
+        ng-model="representant.dateNaissance"
+        input-date
+        date-autocomplete
+        placeholder="JJ/MM/AAAA"
+        aria-describedby="help-date-de-naissance">
+      <div ng-messages="getError('dateDeNaissance')" ng-if="forms.representantForm.$submitted">
+        <p class="help-block" id="help-date-de-naissance" ng-message='inputDate'>Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
       </div>
     </div>
-  </section>
+  </div>
+
+</section>
 
 <section class="identite-section">
   <div class="form-group">


### PR DESCRIPTION
Ajustement graphiques :
Elargir les champs "Date de naissance"
Afficher "Pays" de la même manière que dans le formulaire "Identité du représentant légal