### PR TITLE
[Lot3.2_bugfix03] n°16 & 11 => 16 : ajouter un message d'erreur si le champ obligatoire n'est pas renseigné; 11 : ajouter le point d'interrogation manquant

### DIFF
--- a/client/components/detail/precisez_pourcent.html
+++ b/client/components/detail/precisez_pourcent.html
@@ -1,10 +1,10 @@
 <div class="row form-horizontal control-group">
-  <label class="col-md-3 control-label" for="inputPourcent" ng-bind-html="answer.detailLabel"></label>
+  <label class="col-md-3 control-label" for="inputPourcent_{{answer.detailModel}}" ng-bind-html="answer.detailLabel"></label>
   <div class="col-md-2 input-group">
-    <input id="inputPourcent" type="number" name="quotite" class="form-control" ng-model="sectionModel[answer.detailModel]" min="0" max="100" placeholder="{{answer.placeholder}}" required>
+    <input id="inputPourcent_{{answer.detailModel}}" name="inputPourcent_{{answer.detailModel}}"  type="number" class="form-control" ng-model="sectionModel[answer.detailModel]" min="0" max="100" placeholder="{{answer.placeholder}}" required>
     <!--<div class="input-group-addon">%</div> -->
   </div>
-  <div ng-messages="questionForm.quotite.$error" ng-if="questionForm.showError">
+  <div ng-messages="questionForm['inputPourcent_' + answer.detailModel].$error" ng-if="questionForm.showError">
     <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
     <div class="help-block" ng-message='number,min,max'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
   </div>

--- a/client/components/detail/precisez_pourcent.html
+++ b/client/components/detail/precisez_pourcent.html
@@ -1,7 +1,13 @@
 <div class="row form-horizontal control-group">
   <label class="col-md-3 control-label" for="inputPourcent" ng-bind-html="answer.detailLabel"></label>
   <div class="col-md-2 input-group">
-    <input id="inputPourcent" type="number" class="form-control" ng-model="sectionModel[answer.detailModel]" min="0" max="100" placeholder="{{answer.placeholder}}" required>
+    <input id="inputPourcent" type="number" name="quotite" class="form-control" ng-model="sectionModel[answer.detailModel]" min="0" max="100" placeholder="{{answer.placeholder}}" required>
     <!--<div class="input-group-addon">%</div> -->
+  </div>
+  <div ng-messages="questionForm.quotite.$error" ng-if="questionForm.showError">
+    <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
+    <div class="help-block" ng-message='number'><i class="fa fa-warning"></i> pourcentage invalide</div>
+    <div class="help-block" ng-message='min'><i class="fa fa-warning"></i> pourcentage invalide</div>
+    <div class="help-block" ng-message='max'><i class="fa fa-warning"></i> pourcentage invalide</div>
   </div>
 </div>

--- a/client/components/detail/precisez_pourcent.html
+++ b/client/components/detail/precisez_pourcent.html
@@ -6,8 +6,8 @@
   </div>
   <div ng-messages="questionForm.quotite.$error" ng-if="questionForm.showError">
     <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
-    <div class="help-block" ng-message='number'><i class="fa fa-warning"></i> pourcentage invalide</div>
-    <div class="help-block" ng-message='min'><i class="fa fa-warning"></i> pourcentage invalide</div>
-    <div class="help-block" ng-message='max'><i class="fa fa-warning"></i> pourcentage invalide</div>
+    <div class="help-block" ng-message='number'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
+    <div class="help-block" ng-message='min'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
+    <div class="help-block" ng-message='max'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
   </div>
 </div>

--- a/client/components/detail/precisez_pourcent.html
+++ b/client/components/detail/precisez_pourcent.html
@@ -6,8 +6,6 @@
   </div>
   <div ng-messages="questionForm.quotite.$error" ng-if="questionForm.showError">
     <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
-    <div class="help-block" ng-message='number'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
-    <div class="help-block" ng-message='min'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
-    <div class="help-block" ng-message='max'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
+    <div class="help-block" ng-message='number,min,max'><i class="fa fa-warning"></i> Veuillez saisir un nombre entre 0 et 100.</div>
   </div>
 </div>

--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -226,7 +226,7 @@
             "model": true,
             "detailUrl": "components/detail/precisez.html",
             "detailModel": "detailIndemnisation",
-            "detailLabel": "Auprès de quel organisme",
+            "detailLabel": "Auprès de quel organisme ?",
             "detailType": "text"
           },
           {


### PR DESCRIPTION
A la question "Du fait de handicap de [Prénom nom]", lors du clic sur la case à cocher "Vous exercez une activité professionnelle à temps partiel", si le champ de saisie "Précisez la quotité en pourcentage" n'est pas rempli, ajouter le message d'erreur en gris : "[fa-warning] Ce champ est obligatoire"