### PR TITLE
[Lot3.2_RecettePasse2] Mantis 7047 Formulation CERFA pour une structure renseignée dont la prise de contact (oui/non) n'est pas renseignée

### DIFF
--- a/server/components/register-handlebars.js
+++ b/server/components/register-handlebars.js
@@ -47,7 +47,13 @@ Handlebars.registerHelper('moment', function(str) {
 });
 
 Handlebars.registerHelper('contact', function(str) {
-  return str === 'oui' ? 'et a déjà pris contact' : 'mais n\'a pas encore pris contact';
+  let contact;
+  if(str){
+    contact = str === 'oui' ? 'et a déjà pris contact' : 'mais n\'a pas encore pris contact';
+  } else {
+    contact = '';
+  }
+  return contact;
 });
 
 Handlebars.registerHelper('ntobr', function(str) {


### PR DESCRIPTION
Lors de la demande, dans les formulaires suivants, lorsque l'usager, après avoir indiqué une structure qui pourrait répondre à ses attentes, ne clique ni sur "Oui" ni sur "Non" (choix proposé lorsque l'on renseigne une structure), alors il est indiqué dans le PDF récapitulatif qu'il ne l'a pas contacté. C'est à dire :
- **"A identifié la structure [Nom de la structure] mais n'a pas encore pris contact"**

Questionnaires concernés:

- Vie quotidienne
- Vie scolaire et étudiante
- Vie au travail
- Vie de votre aidant familial

**Attendu :**

Dans le cas ou l'usager ne clique ni sur "Oui, ni sur "Non, renseigner:

- **"A identifié la structure [Nom de la structure]"**