### PR TITLE
[Lot 4] N°01 - Demande - Griser les blocs tant que le bloc beneficiare n'est pas rempli convenablement

### DIFF
--- a/client/app/demande/demande.controller.js
+++ b/client/app/demande/demande.controller.js
@@ -30,6 +30,16 @@ angular.module('impactApp').controller('DemandeCtrl', function(
   this.sendRequest = () => {
     const missingSections = DemandeService.getMissingSection(demande, currentUser);
 
+    if (missingSections.indexOf('beneficiaire') !== -1) {
+      $anchorScroll(missingSections[0]);
+      toastr.error('Vous n\'avez pas fini de remplir la section « Bénéficiaire ».', 'Erreur de la création de la demande');
+      missingSections.forEach((sectionId) => {
+        this.options[sectionId].error = true;
+      });
+
+      return;
+    }
+
     if (missingSections) {
       $anchorScroll(missingSections[0]);
       toastr.error('Vous n\'avez pas fini de remplir les parties obligatoires de ce profil.', 'Erreur de la création de la demande');

--- a/client/components/demande-category/demande-category.controller.js
+++ b/client/components/demande-category/demande-category.controller.js
@@ -37,5 +37,6 @@ angular.module('impactApp').controller('DemandeCategoryCtrl', function($state, D
     }
   };
 
-  this.completion = this.completion || this.computeCompletion();
+  // les sections restes grises même completes lorsque le bénéficiaire n'est pas renseigné
+  this.completion = (this.options.model === 'identites.beneficiaire' || DemandeService.getBeneficiaireCompletion(this.demande)) && (this.completion || this.computeCompletion());
 });

--- a/client/components/service/demande.service.js
+++ b/client/components/service/demande.service.js
@@ -117,8 +117,16 @@ angular.module('impactApp')
       return missingSections.length > 0 ? missingSections : null;
     }
 
-    function getCompletion(demande) {
+    function getBeneficiaireCompletion(demande) {
       if (!demande.data || !demande.data.identites || !demande.data.identites.beneficiaire) {
+        return false;
+      }
+
+      return true;
+    }
+
+    function getCompletion(demande) {
+      if (!getBeneficiaireCompletion(demande)) {
         return false;
       }
 
@@ -223,6 +231,7 @@ angular.module('impactApp')
       estAdulte: _estAdulte,
       estMineur: _estMineur,
       estEnfant: _estEnfant,
+      getBeneficiaireCompletion,
       getCompletion,
       getMissingSection,
       needUploadCV,

--- a/client/components/service/demande.service.js
+++ b/client/components/service/demande.service.js
@@ -96,22 +96,22 @@ angular.module('impactApp')
 
       if (!demande || !demande.data || !demande.data.identites || !demande.data.identites.beneficiaire || !demande.data.identites.beneficiaire.localite || !demande.data.identites.beneficiaire.code_postal || !demande.data.identites.beneficiaire.nomVoie || !demande.data.identites.beneficiaire.dateNaissance || !demande.data.identites.beneficiaire.nationalite || !demande.data.identites.beneficiaire.sexe || !demande.data.identites.beneficiaire.prenom || !demande.data.identites.beneficiaire.nom || !demande.data.identites.beneficiaire.email || !demande.data.identites.beneficiaire.numero_secu || !demande.data.identites.beneficiaire.assurance || (demande.data.identites.beneficiaire.assurance === 'autre' && !demande.data.identites.beneficiaire.assurance_precisez)) {
         missingSections.push('beneficiaire');
-      }
+      } else {
+        if (autoriteObligatoire(demande) && !demande.data.identites.autorite) {
+          missingSections.push('autorite');
+        }
 
-      if (autoriteObligatoire(demande) && !demande.data.identites.autorite) {
-        missingSections.push('autorite');
-      }
+        if (representantObligatoire(demande) && !demande.data.identites.representant) {
+          missingSections.push('representant');
+        }
 
-      if (representantObligatoire(demande) && !demande.data.identites.representant) {
-        missingSections.push('representant');
-      }
+        if (!demande.data.vie_quotidienne || !demande.data.vie_quotidienne.__completion) {
+          missingSections.push('vieQuotidienne');
+        }
 
-      if (!demande.data.vie_quotidienne || !demande.data.vie_quotidienne.__completion) {
-        missingSections.push('vieQuotidienne');
-      }
-
-      if (!getDocumentCompletion(demande)) {
-        missingSections.push('documents');
+        if (!getDocumentCompletion(demande)) {
+          missingSections.push('documents');
+        }
       }
 
       return missingSections.length > 0 ? missingSections : null;


### PR DESCRIPTION
ETQ usager dans la page de création d'une demande, tous les blocs sont grisés tant que l’usager n’a pas rempli les champs obligatoires du questionnaire « Identité du bénéficiaire »

Les boutons "Modifier" des blocs grisés ne sont pas cliquables

Gérer le message d'erreur :
Au clic sur "Envoyer la demande", le message d'erreur suivant s'affiche:

Vous n'avez pas fini de remplir la section "Bénéficiaire"