### PR TITLE
[Lot 4] N°21 - Tableau de bord - Telecharger en masse

### DIFF
--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -96,15 +96,25 @@ angular.module('impactApp')
 
       if (selectedRequests.length === 1) {
         var request = _.find(this.requests, 'isSelected');
-
-        $window.open('api/requests/' + request.shortId + '/pdf/agent?access_token=' + this.token);
-
+        request.isDownloaded = 'true';
+        RequestResource.update(request).$promise.then(result => {
+          $window.open('api/requests/' + result.shortId + '/pdf/agent?access_token=' + this.token);
+        });
       } else {
         if (selectedRequests.length > 1) {
-          $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + this.token);
+          const update = function(request) {
+            request.isDownloaded = 'true';
+            return RequestResource.update(request).$promise;
+          };
+
+          const download =  function() {
+            $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + $cookies.get('token'));
+          };
+          actionOnSelectedRequests(requests, update, download);
         }
       }
     };
+
 
     function archiveRequests(requests) {
       const archive = function(request) {

--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -110,11 +110,11 @@ angular.module('impactApp')
           const download =  function() {
             $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + $cookies.get('token'));
           };
+
           actionOnSelectedRequests(requests, update, download);
         }
       }
     };
-
 
     function archiveRequests(requests) {
       const archive = function(request) {

--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -23,7 +23,7 @@
           Action <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu" aria-labelledby="split-button">
-          <li role="menuitem">
+          <li role="menuitem" ng-if="workflowListCtrl.showDownloadAndDeleteButtons">
             <a href="#" ng-click="workflowListCtrl.downloadRequests()"><i class="fa fa-download"></i> Télécharger les demandes</a>
           </li>
           <li role="menuitem" ng-if="status !== 'irrecevable'">


### PR DESCRIPTION
*EBE p.44, 52*

**Attendu : Adaptation du tableau de bord des demandes validées ou irrecevables**

La sélection de plusieurs demandes suivie d’un clic sur le bouton « Action » permet de les télécharger ou de les supprimer en masse. Actions proposées:

 - **[fa-download] « Télécharger les demandes »**
 - [fa-trash] « Supprimer les demandes validées téléchargées » *=> Cf. carte 20*

**L’exécution de l’action de masse « télécharger » **
 - Télécharge les demandes sémectionnées
 - **Fait apparaître** le bouton **[fa-trash] « Supprimer »** *(pour les demandes cochées)*

*NB : Action existante, il faut ajouter l'appel à la fonction*