### PR TITLE
[Lot 4] N°20 - Tableau de bord - Supprimer en masse

### DIFF
--- a/client/app/dashboard/workflow/detail/detail.html
+++ b/client/app/dashboard/workflow/detail/detail.html
@@ -9,7 +9,7 @@
           download>
           <i class="fa fa-download"></i>&nbsp;Télécharger
         </a>
-        <a ng-show="request.isDownloaded" target="#" class="btn btn-danger" ng-click="workflowCtrl.openDeleteModal(request)" >
+        <a ng-show="(request.status === 'irrecevable' || request.status === 'validee') && request.isDownloaded" target="#" class="btn btn-danger" ng-click="workflowCtrl.openDeleteModal(request)" >
           <i class="fa fa-trash"></i>&nbsp;Supprimer
         </a>
         <button class="btn btn-link" ng-click="workflowDetailCtrl.toggleDetail()">{{showDetail ? 'Cacher' : 'Afficher'}} détails</button>

--- a/client/app/dashboard/workflow/detail/modalDelete.html
+++ b/client/app/dashboard/workflow/detail/modalDelete.html
@@ -3,9 +3,9 @@
 </div>
 <div class="modal-body">
   <div class="embed-responsive embed-responsive-16by9">
-    <p>Vous êtes sur le point de supprimer définitivement la demande suivante du service :
-      <ul>
-        <li>Demande n° {{modalDeleteCtrl.shortId}}</li>
+    <p>Vous êtes sur le point de supprimer définitivement {{modalDeleteCtrl.requests.length === 1 ? 'la demande suivante' : 'les demandes suivantes'}} du service :
+      <ul ng-repeat="request in modalDeleteCtrl.requests">
+        <li>Demande n° {{request.shortId}}</li>
       </ul>
     </p>
     <p />

--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -96,15 +96,25 @@ angular.module('impactApp')
 
       if (selectedRequests.length === 1) {
         var request = _.find(this.requests, 'isSelected');
-
-        $window.open('api/requests/' + request.shortId + '/pdf/agent?access_token=' + this.token);
-
+        request.isDownloaded = 'true';
+        RequestResource.update(request).$promise.then(result => {
+          $window.open('api/requests/' + result.shortId + '/pdf/agent?access_token=' + this.token);
+        });
       } else {
         if (selectedRequests.length > 1) {
-          $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + this.token);
+          const update = function(request) {
+            request.isDownloaded = 'true';
+            return RequestResource.update(request).$promise;
+          };
+
+          const download =  function() {
+            $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + $cookies.get('token'));
+          };
+          actionOnSelectedRequests(requests, update, download);
         }
       }
     };
+
 
     function archiveRequests(requests) {
       const archive = function(request) {

--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -110,11 +110,11 @@ angular.module('impactApp')
           const download =  function() {
             $window.open('api/requests/download?short_ids=' + JSON.stringify(selectedRequests) + '&access_token=' + $cookies.get('token'));
           };
+
           actionOnSelectedRequests(requests, update, download);
         }
       }
     };
-
 
     function archiveRequests(requests) {
       const archive = function(request) {

--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -112,7 +112,7 @@
             </a>
           </td>
           <td class="col-md-2">
-            <button ng-show="request.isDownloaded" class="btn btn-link red-color" ng-click="workflowCtrl.openDeleteModal(request)">
+            <button ng-show="workflowListCtrl.showDownloadAndDeleteButtons && request.isDownloaded" class="btn btn-link red-color" ng-click="workflowCtrl.openDeleteModal(request)">
               <i class="fa fa-trash"></i>&nbsp;Supprimer</i>
             </button>
           </td>

--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -30,7 +30,7 @@
             <a href="#" ng-click="workflowListCtrl.openArchiveModal()"><i class="fa fa-archive"></i> Archiver les demandes</a>
           </li>
           <li role="menuitem" ng-if="workflowListCtrl.status === 'validee' || workflowListCtrl.status === 'irrecevable'">
-              <a href="#" ng-click="#">
+              <a href="#" ng-click="workflowListCtrl.allSelectedRequestsDownloadOpenModal()">
                 <i class="fa fa-trash"></i> Supprimer les demandes {{workflowListCtrl.status === 'validee' ? 'validées' : 'irrecevables'}} téléchargées
               </a>
           </li>

--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -29,6 +29,11 @@
           <li role="menuitem" ng-if="status !== 'irrecevable'">
             <a href="#" ng-click="workflowListCtrl.openArchiveModal()"><i class="fa fa-archive"></i> Archiver les demandes</a>
           </li>
+          <li role="menuitem" ng-if="workflowListCtrl.status === 'validee' || workflowListCtrl.status === 'irrecevable'">
+              <a href="#" ng-click="#">
+                <i class="fa fa-trash"></i> Supprimer les demandes {{workflowListCtrl.status === 'validee' ? 'validées' : 'irrecevables'}} téléchargées
+              </a>
+          </li>
         </ul>
 
         <button type="button" class="btn btn-link btn-refresh" ng-class="{ 'refreshing': workflowlistctrl.isRefreshing }" ng-click="workflowlistctrl.refresh()">

--- a/client/app/dashboard/workflow/workflow.controller.js
+++ b/client/app/dashboard/workflow/workflow.controller.js
@@ -9,9 +9,11 @@ angular.module('impactApp')
         controllerAs: 'modalDeleteCtrl',
         size: 'md',
         controller(navUserId, navStatus, $modalInstance, RequestResource) {
+          this.requests = [];
           this.shortId = request.shortId;
           this.navUserId = navUserId;
           this.navStatus = navStatus;
+          this.requests.push(request);
           this.delete = function() {
               RequestResource.remove({shortId: this.shortId}).$promise.then(() => {
                 $modalInstance.close();


### PR DESCRIPTION

La sélection de plusieurs demandes suivie d’un clic sur le bouton « Action » permet de les télécharger ou de les supprimer en masse. Actions proposées:

 - [fa-download] « Télécharger les demandes » => *Cf carte 21*
 - **[fa-trash] « Supprimer les demandes validées téléchargées »**

**L’exécution de l’action de masse « Supprimer » **

**Cas 1 :** Toutes les demandes sélectionnées ont déjà été téléchargées:
 - Suppression de l'ensemble des demandes cochées 
 - Affichage de la pop-in de confirmation de suppression 
***ou***
**Cas 2 :** Si au moins 1 demande n'a pas déjà été téléchargée:
  - Les demandes sélectionnées ne sont pas supprimées
  - Les cases de ces demandes sont décochées
  - Affichage du message d'erreur 
  Le message d'erreur ne doit pas indiquer précisément quelle(s) demande(s) n'a(n'ont) pas déjà été téléchargée(s) 