### PR TITLE
[Lot 3.2_qualifInternePasse2] Bug d'affichage des réponses dans le CERFA - Mantis 7029 - sous-réponse sur les frais de séjour en internat

### DIFF
--- a/server/components/recapitulatif.js
+++ b/server/components/recapitulatif.js
@@ -143,9 +143,12 @@ function computeAnswers(question, trajectoireAnswers) {
           }
           break;
         case 'fraisInternat':
-          if(detail){
-            answer.detail = 'Ses frais de séjour sont-ils intégralement pris en charge par l\'assurance maladie, l\'Etat ou l`\'aide sociale ? ';
-            answer.detail += detail.text;
+          if(detail !== undefined){
+            if(detail){
+              answer.detail = 'Les frais de séjour sont intégralement pris en charge par l\'assurance maladie, l\'Etat ou l\'aide sociale';
+            } else {
+              answer.detail = 'Les frais de séjour ne sont pas intégralement pris en charge par l\'assurance maladie, l\'Etat ou l\'aide sociale';
+            }
           }
           break;
         case 'date&categorie':


### PR DESCRIPTION
Constats :

Dans Vie scolaire et étudiante, à la question "Est-il placé en internat?" la réponse "Oui" est affichée, puis la sous-réponse " 'true' " est affichée
Attendus :

Modifier la façon dont la réponse à la sous question s'affiche dans le CERFA par :

Si l'usager répond oui à la sous-question :
° Oui
° Les frais de séjour sont intégralement pris en charge par l'assurance maladie, l'Etat ou l'aide sociale

Si l'usager répond non à la sous-question :
° Oui
° Les frais de séjour ne sont pas intégralement pris en charge par l'assurance maladie, l'Etat ou l'aide sociale

Modifier "Ses" par "Les" dans la sous-question affichée dans le formulaire en ligne