### PR TITLE
[Lot 3.2_RecettePasse2] rafraîchissement bloc confirmer compte mail sous IE & [Recette_Lot anos 3.2_bug] auto-complétion du champs adresse du formulaire bénéficiaire

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -32,13 +32,11 @@ angular.module('impactApp', [
     treeConfig.dragClass = 'angular-ui-tree-drag';
 
     // disable IE ajax request caching
-    $httpProvider.defaults.headers.common['Cache-Control'] = 'no-cache';
+    //$httpProvider.defaults.headers.common['Cache-Control'] = 'no-cache';
     $httpProvider.defaults.cache = false;
     if (!$httpProvider.defaults.headers.get) {
       $httpProvider.defaults.headers.get = {};
     }
-
-    $httpProvider.defaults.headers.get['If-Modified-Since'] = '0';
   })
   .run(function($rootScope, $window, $location, $state) {
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toStateParams) {

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -32,7 +32,6 @@ angular.module('impactApp', [
     treeConfig.dragClass = 'angular-ui-tree-drag';
 
     // disable IE ajax request caching
-    //$httpProvider.defaults.headers.common['Cache-Control'] = 'no-cache';
     $httpProvider.defaults.cache = false;
     if (!$httpProvider.defaults.headers.get) {
       $httpProvider.defaults.headers.get = {};

--- a/client/app/mon_compte/mon_compte.controller.js
+++ b/client/app/mon_compte/mon_compte.controller.js
@@ -3,6 +3,18 @@
 angular.module('impactApp')
   .controller('MonCompteCtrl', function($scope, $state, User, Auth, currentUser) {
     $scope.errors = {};
+
+    if (currentUser.unconfirmed === true) {
+      var configNoCache = {
+        headers: {common: {'Cache-Control': 'no-cache'}}
+      };
+
+      User.get(currentUser._id, configNoCache).$promise
+      .then(function(user) {
+        currentUser.unconfirmed = user.unconfirmed;
+      });
+    }
+
     $scope.user = currentUser;
 
     $scope.changePassword = function(form) {

--- a/client/app/profil/profil.controller.js
+++ b/client/app/profil/profil.controller.js
@@ -26,11 +26,11 @@ angular.module('impactApp').controller('ProfilCtrl', function(
   this.autoriteObligatoire = ProfileService.autoriteObligatoire(profile);
 
   if (currentUser.unconfirmed === true) {
-    var config = {
-      //headers : {common : {'Cache-Control' : 'no-cache'}}
-     };
+    var configNoCache = {
+      headers: {common: {'Cache-Control': 'no-cache'}}
+    };
 
-    User.get(currentUser._id, config).$promise
+    User.get(currentUser._id, configNoCache).$promise
     .then(function(user) {
       currentUser.unconfirmed = user.unconfirmed;
     });

--- a/client/app/profil/profil.controller.js
+++ b/client/app/profil/profil.controller.js
@@ -26,7 +26,11 @@ angular.module('impactApp').controller('ProfilCtrl', function(
   this.autoriteObligatoire = ProfileService.autoriteObligatoire(profile);
 
   if (currentUser.unconfirmed === true) {
-    User.get(currentUser._id).$promise
+    var config = {
+      //headers : {common : {'Cache-Control' : 'no-cache'}}
+     };
+
+    User.get(currentUser._id, config).$promise
     .then(function(user) {
       currentUser.unconfirmed = user.unconfirmed;
     });

--- a/client/components/adresse.data.gouv/adresse.data.gouv.js
+++ b/client/components/adresse.data.gouv/adresse.data.gouv.js
@@ -14,18 +14,10 @@ angular.module('impactApp')
             lat: mainLocation.coordinates.coordy,
             lon: mainLocation.coordinates.coordx,
             limit: 8
-          },
-          headers: {
-            'Cache-Control': undefined
-          },
+          }
         })
         .then(function(response) {
-          console.info('response.data.features   ' + response.data.features);
           return response.data.features;
-
-        })
-        .catch((err) => {
-          console.info('erqSDQWD   ' + err);
         });
       },
 

--- a/client/components/adresse.data.gouv/adresse.data.gouv.js
+++ b/client/components/adresse.data.gouv/adresse.data.gouv.js
@@ -14,10 +14,18 @@ angular.module('impactApp')
             lat: mainLocation.coordinates.coordy,
             lon: mainLocation.coordinates.coordx,
             limit: 8
-          }
+          },
+          headers: {
+            'Cache-Control': undefined
+          },
         })
         .then(function(response) {
+          console.info('response.data.features   ' + response.data.features);
           return response.data.features;
+
+        })
+        .catch((err) => {
+          console.info('erqSDQWD   ' + err);
         });
       },
 


### PR DESCRIPTION
Suite à la confirmation de son adresse mail, au clic sur le bouton "Retourner au profil", l'usager est redirigé sur la page de création de sa demande
Constaté pendant la recette du lot d'anomalies 3.2 _ le 19/04/2018 :

L'auto-complétion du champs adresse du formulaire Identité du bénéficiaire ne fonctionne plus. Il "saute" (recharge?) à chaque entrée clavier mais ne trouve aucun résultat.

Attendu :

Fonctionnement de l'autocomplétion