### PR TITLE
 [Lot 3.2_RecettePasse2] rafraîchissement bloc confirmer compte mail sous IE & [Recette_Lot anos 3.2_bug] auto-complétion du champs adresse du formulaire bénéficiaire

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -36,6 +36,8 @@ angular.module('impactApp', [
     if (!$httpProvider.defaults.headers.get) {
       $httpProvider.defaults.headers.get = {};
     }
+
+    $httpProvider.defaults.headers.get.Pragma = 'no-cache';
   })
   .run(function($rootScope, $window, $location, $state) {
     $rootScope.$on('$stateChangeSuccess', function(event, toState, toStateParams) {

--- a/client/app/mon_compte/mon_compte.controller.js
+++ b/client/app/mon_compte/mon_compte.controller.js
@@ -5,11 +5,7 @@ angular.module('impactApp')
     $scope.errors = {};
 
     if (currentUser.unconfirmed === true) {
-      var configNoCache = {
-        headers: {common: {'Cache-Control': 'no-cache'}}
-      };
-
-      User.get(currentUser._id, configNoCache).$promise
+      User.get(currentUser._id).$promise
       .then(function(user) {
         currentUser.unconfirmed = user.unconfirmed;
       });

--- a/client/app/profil/profil.controller.js
+++ b/client/app/profil/profil.controller.js
@@ -26,11 +26,7 @@ angular.module('impactApp').controller('ProfilCtrl', function(
   this.autoriteObligatoire = ProfileService.autoriteObligatoire(profile);
 
   if (currentUser.unconfirmed === true) {
-    var configNoCache = {
-      headers: {common: {'Cache-Control': 'no-cache'}}
-    };
-
-    User.get(currentUser._id, configNoCache).$promise
+    User.get(currentUser._id).$promise
     .then(function(user) {
       currentUser.unconfirmed = user.unconfirmed;
     });

--- a/client/components/adresse.data.gouv/adresse.data.gouv.js
+++ b/client/components/adresse.data.gouv/adresse.data.gouv.js
@@ -14,6 +14,9 @@ angular.module('impactApp')
             lat: mainLocation.coordinates.coordy,
             lon: mainLocation.coordinates.coordx,
             limit: 8
+          },
+          headers: {
+            Pragma: undefined
           }
         })
         .then(function(response) {


### PR DESCRIPTION
**Constat mantis 6958 du 24/01/18 :**
*Suite à la confirmation de son adresse mail, au clic sur le bouton "Retourner au profil", l'usager est redirigé sur la page de création de sa demande. Cependant, l'usager voit toujours le bloc "Confirmer votre compte mail" affiché en rouge. Il doit actualiser la page pour que le bloc disparaisse. 
Pourriez-vous faire en sorte que le bloc disparaisse immédiatement à la suite du clic sur le bouton "Retourner au profil" ?*