### PR TITLE
[Lot 4] N°06 - Demande - Bloquage de la modification des documents complémentaires d'une demande mise en attente

### DIFF
--- a/client/app/demande/documents/documents.html
+++ b/client/app/demande/documents/documents.html
@@ -10,16 +10,16 @@
     ng-repeat="documentType in demandeDocumentsCtrl.selectedDocumentTypes"
     class="row-document-type"
     ng-class="{
-      'invalid': demandeDocumentsCtrl.isInvalid(documentType),
-      'complete': demandeDocumentsCtrl.isComplete(documentType),
-      'incomplete': demandeDocumentsCtrl.isEmpty(documentType)}">
+      'invalid': demandeDocumentsCtrl.isInvalid(documentType) && demandeDocumentsCtrl.isMandatory(documentType),
+      'complete': demandeDocumentsCtrl.isComplete(documentType) && demandeDocumentsCtrl.isMandatory(documentType),
+      'incomplete': demandeDocumentsCtrl.isEmpty(documentType) && demandeDocumentsCtrl.isMandatory(documentType)}">
     <div class="header-document-type">
       <div class="title-card">
         <h4>
           {{documentType.label}}
           <span class="label label-default" ng-if="demandeDocumentsCtrl.isEmpty(documentType)">À renseigner</span>
-          <span class="label label-success" ng-if="demandeDocumentsCtrl.isComplete(documentType)">Complet</span>
-          <span class="label label-danger"ng-if="demandeDocumentsCtrl.isInvalid(documentType)">Invalide</span>
+          <span class="label label-success" ng-if="demandeDocumentsCtrl.isComplete(documentType) && demandeDocumentsCtrl.isMandatory(documentType)">Complet</span>
+          <span class="label label-danger"ng-if="demandeDocumentsCtrl.isInvalid(documentType) && demandeDocumentsCtrl.isMandatory(documentType)">Invalide</span>
         </h4>
         <p ng-bind-html="documentType.desc"></p>
 


### PR DESCRIPTION
Attendu:

Côté demande usager (le côté tableau de bord agent est spécifié dans une autre carte)

Page Usager d’une demande en attente :

Les documents facultatifs seront toujours affichés
Le caractère conforme ou non conforme des documents complémentaires ne sera plus affiché :
Les documents facultatifs se voit attribuer un bandeau blanc (ni vert, ni rouge)
Aucun état n’est associé aux documents facultatifs ajoutés par l’usager à l’émission de sa demande
Lorsque l’usager clique sur « Ajouter un document », la mention "à renseigner" est présente dans l’entête blanche, sinon, aucune information n’est présente