### PR TITLE
[Lot 4_bugfix1] N°30 - Tableau de bord - Amélioration de la gestion des comptes agents

### DIFF
--- a/client/app/dashboard/users/agents/edit.controller.js
+++ b/client/app/dashboard/users/agents/edit.controller.js
@@ -25,21 +25,18 @@ angular.module('impactApp')
         } else {
           $scope.user.role = 'adminMdph';
           $scope.user.mdph = currentMdph._id;
-          $scope.user.$saveAgent(
-            function() {
-              $state.go('^', {}, {reload: true});
-            },
+          $scope.user.$saveAgent().catch(function(err) {
+            err = err.data;
+            $scope.errors = {};
 
-            function(err) {
-              err = err.data;
-              $scope.errors = {};
-
-              // Update validity of form fields that match the mongoose errors
-              angular.forEach(err.errors, function(error, field) {
-                form[field].$setValidity('mongoose', false);
-                $scope.errors[field] = error.message;
-              });
+            // Update validity of form fields that match the mongoose errors
+            angular.forEach(err.errors, function(error, field) {
+              form[field].$setValidity('mongoose', false);
+              $scope.errors[field] = error.message;
             });
+          });
+
+          $state.go('^', {}, {reload: false});
         }
       }
     };

--- a/client/app/dashboard/users/agents/edit.html
+++ b/client/app/dashboard/users/agents/edit.html
@@ -5,7 +5,7 @@
   </div>
   <form class="form-horizontal" name="forms.form" ng-submit="update(forms.form)" novalidate>
   <div class="row">
-    <div class="col-sm-7">
+    <div ng-class="{ 'col-sm-7': !user._id }">
       <div class="form-group required" ng-class="{ 'has-error': forms.form.nom.$invalid && forms.form.$submitted }">
             <div class="col-sm-3 text-right">
               <label for="nom" class="control-label">Nom</label>
@@ -39,13 +39,13 @@
       <password-field user="user" libelle="Mot de passe"  horizontal="true" ng-if="!user._id"/>
     </div>
 
-    <div class="col-sm-5">
+    <div class="col-sm-5" ng-if="!user._id">
       <password-rules-alert/>
     </div>
 
   </div>
   <div class="row">
-    <div class="col-sm-7">
+    <div ng-class="{ 'col-sm-7': !user._id }">
       <div class="form-group">
         <label for="secteur" class="col-sm-3 control-label">Secteurs associés</label>
           <div class="col-sm-9">


### PR DESCRIPTION
Création d'un agent

Au clic sur "Enregistrer" pour la création d'un nouvel agent, une page idnetique vide avec msg d'erreur apparaît un court instant avant la redirection adéquate.
Modification d'un agent

Présence inopinée du bloc informatif de modification de mot de passe (alors qu'on ne peut pas modifier le mot de passe de l'agent)