### PR TITLE
[Lot4_bug] N°bugA - Tableau de bord agent - compteurs non rafraîchis

### DIFF
--- a/server/api/mdph/mdph.controller.js
+++ b/server/api/mdph/mdph.controller.js
@@ -243,7 +243,7 @@ export function showRequestsByStatus(req, res) {
       const promises = users.map(user => {
         return Request
           .aggregate([
-            {$match: {mdph: req.mdph.zipcode, evaluators: user._id }},
+            {$match: {mdph: req.mdph.zipcode, evaluators: user._id, deletedAt: { $exists: false } }},
             {$group: {_id: '$status', count: {$sum: 1} }}
           ])
           .exec()


### PR DESCRIPTION
**Constat :**
Dans le panneau de navigation à gauche dans le tableau de bord de l'agent, les compteurs des demandes "Mes demandes" ne sont pas rafraîchis. Ils incrémentent mais ne décrémentent pas à la suppression des demandes.

**Attendu:**
Gérer la décrémentation des compteurs de demandes lors de la suppression