### PR TITLE
[Lot 4_bugfix1] N°13 - Profil et demandes - Supprimer une demande

### DIFF
--- a/server/api/profile/profile.controller.js
+++ b/server/api/profile/profile.controller.js
@@ -109,7 +109,7 @@ export function showLastRequest(req, res) {
     .exec()
     .then(request => {
       if (!request) {
-        return RequestController.create(req, res);
+        return respondWithResult(res);
       }
 
       req.request = request;

--- a/server/api/profile/profile.controller.js
+++ b/server/api/profile/profile.controller.js
@@ -109,7 +109,7 @@ export function showLastRequest(req, res) {
     .exec()
     .then(request => {
       if (!request) {
-        return respondWithResult(res);
+        return res.sendStatus(404);
       }
 
       req.request = request;


### PR DESCRIPTION
Lorsque je supprime la demande en cours de création, il n'y a pas de création de demande automatique ensuite (le demandeur dispose du bouton de création).
La demande n'est automatiquement créée qu'a la création d'un nouveau profil.
Dans le cas d'une connexion d'un demandeur avec 1 profil et 0 demandes en cours (car supprimée antérieurement), il arrive bien sur le tableau de bord des demandes comme prévu, avec 0 demandes et le bouton de création à dispo