### PR TITLE
[Lot 4_bugfix1] N°18 - Tableau de bord - Telecharger la demande dans le tableau de bord

### DIFF
--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -47,12 +47,12 @@
     <table>
       <tbody ng-repeat="group in workflowListCtrl.groups">
         <tr>
-          <td class="lead" colspan="{{workflowListCtrl.showDownloadAndDeleteButtons ? '8' : '6'}}">
+          <td class="lead" colspan="8">
             {{::group.title}}
           </td>
         </tr>
         <tr ng-hide="filteredRequests.length">
-          <td colspan="{{workflowListCtrl.showDownloadAndDeleteButtons ? '8' : '6'}}">
+          <td colspan="8">
             Pas de demandes
           </td>
         </tr>
@@ -107,9 +107,9 @@
           </td>
           <td>{{::request.submittedAt | date}}</td>
           <td>
-            <a ng-show="workflowListCtrl.showDownloadAndDeleteButtons" href="#" ng-click="workflowCtrl.download(request)">
+            <button ng-show="workflowListCtrl.showDownloadAndDeleteButtons" class="btn btn-link" ng-click="workflowCtrl.download(request)">
               <i class="fa fa-download"></i>&nbsp;Télécharger
-            </a>
+            </button>
           </td>
           <td class="col-md-2">
             <button ng-show="workflowListCtrl.showDownloadAndDeleteButtons && request.isDownloaded" class="btn btn-link red-color" ng-click="workflowCtrl.openDeleteModal(request)">


### PR DESCRIPTION
Fonctionnel OK, Design KO:

    En responsive design, lorsque la largeur de la fenêtre est réduite, les liens Télécharger et Supprimer n'ont pas le même comportement. Leurs icônes respectives sont alignées à gauche pour télécharger, au centre pour Supprimer (Cf. PJ *Recette_gestionColonnesEnModeResponsive). L'alignement au centre est visuellement plus agréable, est-il possible d'homogénéiser le lien Télécharger de la même manière?

    La continuité des interlignes grisées est rompue pour les demandes émsies et en attente sur les 2 dernières colonnes (Cf. PJ Recette_gestionColonnesInterlignes)
