### PR TITLE
[Lot 4_bugfix1] N°20 - Tableau de bord - Supprimer en masse

### DIFF
--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -205,7 +205,7 @@ angular.module('impactApp')
                   $state.go('.', {}, {reload: true});
                 };
 
-                this.actionOnSelectedRequests(this.requests, remove, closeModal);
+                actionOnSelectedRequests(this.requests, remove, closeModal);
               };
 
               this.cancel = function() {


### PR DESCRIPTION
Recette KO:
Constat: Supprimer en masse ne fonctionne pas. Au clique sur le bouton Supprimer dans la pop-up de confirmation des suppressions, rien ne se passe.