### PR TITLE
[Lot 4_bugfix1] N°29 - Tableau de bord - Retour au flux des demandes

### DIFF
--- a/client/app/dashboard/workflow/detail/detail.js
+++ b/client/app/dashboard/workflow/detail/detail.js
@@ -25,7 +25,7 @@ angular.module('impactApp')
         authorized: ['adminMdph']
       })
       .state('dashboard.workflow.detail.documents', {
-        url: '/documents',
+        url: '/documents/:navUserId/:navStatus',
         controller: 'RequestDocumentsCtrl',
         controllerAs: 'requestDocumentsCtrl',
         templateUrl: 'app/dashboard/workflow/detail/documents/documents.html',
@@ -38,7 +38,16 @@ angular.module('impactApp')
                 return !documentType.mandatory;
               });
             });
+          },
+
+          navUserId: function($stateParams) {
+            return $stateParams.navUserId;
+          },
+
+          navStatus: function($stateParams) {
+            return $stateParams.navStatus;
           }
+
         }
       })
       .state('dashboard.workflow.detail.comments', {

--- a/client/app/dashboard/workflow/detail/documents/documents.controller.js
+++ b/client/app/dashboard/workflow/detail/documents/documents.controller.js
@@ -8,7 +8,7 @@ angular.module('impactApp')
     $scope.currentUser = currentUser;
     $scope.token = Auth.getToken();
 
-    if(navUserId !== '' && navStatus !== ''){
+    if (navUserId !== '' && navStatus !== '') {
       $scope.currentMenu(navUserId, navStatus);
     }
 

--- a/client/app/dashboard/workflow/detail/documents/documents.controller.js
+++ b/client/app/dashboard/workflow/detail/documents/documents.controller.js
@@ -1,11 +1,16 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('RequestDocumentsCtrl', function($scope, $modal, toastr, Auth, request, documentTypes, currentUser, RequestResource) {
+  .controller('RequestDocumentsCtrl', function($scope, $modal, toastr, Auth, request,
+    navUserId, navStatus, documentTypes, currentUser, RequestResource) {
     $scope.documentTypes = documentTypes;
     $scope.request = request;
     $scope.currentUser = currentUser;
     $scope.token = Auth.getToken();
+
+    if(navUserId !== '' && navStatus !== ''){
+      $scope.currentMenu(navUserId, navStatus);
+    }
 
     function alreadySelected(request, typeId) {
       return _.find(request.data.askedDocumentTypes, function(current) {
@@ -52,7 +57,7 @@ angular.module('impactApp')
             templateUrl: 'app/dashboard/workflow/detail/documents/modal.html',
             controllerAs: 'modalRdc',
             size: 'lg',
-            controller($modalInstance, $state, DemandeService) {
+            controller(navUserId, navStatus, $modalInstance, $state, DemandeService) {
               this.src = `/api/requests/${request.shortId}/generate-reception-mail?access_token=${token}`;
 
               this.ok = function() {
@@ -60,13 +65,23 @@ angular.module('impactApp')
                   id: 'enregistrement'
                 }).then(() => {
                   $modalInstance.close();
-                  $state.go('.', {}, {reload: true});
+                  $state.go('.', {navUserId:navUserId, navStatus:navStatus}, {reload: true});
                 });
               };
 
               this.cancel = function() {
                 $modalInstance.dismiss('cancel');
               };
+            },
+
+            resolve: {
+              navUserId: function() {
+                return $scope.navUserId;
+              },
+
+              navStatus: function() {
+                return $scope.navStatus;
+              }
             }
           });
         } else {


### PR DESCRIPTION
Constat: dans le cas suivant, le bouton n'a aucune action associée: depuis les demandes émises, je clique sur une demande, je la valide (envoi accusé de réception), une fois l'envoi de l'accusé de réception confirmé dans via la pop-up, le bouton retour au flux des demandes n'entraîne pas la redirection vers les demandes émises.