### PR TITLE
[Lot 4_bugfix2] N°12 - Profil et demandes - Afficher la demande courante d'un profil

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -195,7 +195,6 @@ fieldset {
 @import 'admin/mdph/list/admin.mdph.list.scss';
 @import 'apropos/apropos.scss';
 @import 'cgu/cgu.scss';
-@import 'closed/closed.scss';
 @import 'dashboard/dashboard.scss';
 @import 'dashboard/documents/documents.scss';
 @import 'dashboard/list.scss';
@@ -215,6 +214,7 @@ fieldset {
 @import 'gestion/gestion.scss';
 @import 'layout/layout.scss';
 @import 'main/main.scss';
+@import 'mdph/mdph.scss';
 @import 'medecin/medecin.scss';
 @import 'mon_compte/mon_compte.scss';
 @import 'partenaire/partenaire.scss';

--- a/client/app/gestion/demande/gestion.demande.html
+++ b/client/app/gestion/demande/gestion.demande.html
@@ -49,7 +49,9 @@
           <div style="width:20%" class="col-xs-1 col-action" ng-click="gestionDemandeCtrl.deleteCurrentDemande()"></div>
         </div>
         <div class="row">
-          <div class="col-md-12" ng-class="{'col-new': !gestionDemandeCtrl.currentDemande, 'col-new-desabled': gestionDemandeCtrl.currentDemande}" ng-click="gestionDemandeCtrl.createDemande()">Créer une nouvelle demande *</div>
+          <div class="col-md-12"
+          ng-class="{'col-new': !gestionDemandeCtrl.currentDemande, 'col-new-disabled': gestionDemandeCtrl.currentDemande}"
+          ng-click="gestionDemandeCtrl.createDemande()">Créer une nouvelle demande *</div>
         </div>
         <div class="row" >
           <i class="note">* Vous ne pouvez pas créer de nouvelle demande tant qu'une demande est en cours</i>

--- a/client/app/gestion/gestion.scss
+++ b/client/app/gestion/gestion.scss
@@ -137,13 +137,14 @@
     }
   }
 
-  .col-new-desabled {
+  .col-new-disabled {
     background-color: #D0D0D0;
     padding: 10px 15px;
     font-size: 1.2em;
     width: 100%;
     color: #666666;
     text-align: center;
+    cursor: pointer;
 
     &:before {
       content: "\f055";

--- a/client/app/gestion/gestion.scss
+++ b/client/app/gestion/gestion.scss
@@ -144,7 +144,7 @@
     width: 100%;
     color: #666666;
     text-align: center;
-    cursor: pointer;
+    cursor: default;
 
     &:before {
       content: "\f055";


### PR DESCRIPTION
1 - Le bouton "Créer une nouvelle demande" n'est plus cliquable lorsqu'il est grisé (OK), mais il y a une erreur mineure : la souris passe de la flèche à la main indiquant à l'usager qu'il y a un élément cliquable (celà induit en erreur).