### PR TITLE
[Lot4_bug] N°bugB - Tableau de bord agent - affichage du panneau de navigation incomplet

### DIFF
--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -4,12 +4,14 @@ angular.module('impactApp')
   .controller('WorkflowListCtrl', function($scope,
     $cookies, $window, $modal, $q, $state, $rootScope,
     RequestService, RequestResource, MdphResource, userId, status, requests,
-    groupedByAge, currentMdph, banetteUser, toastr) {
+    groupedByAge, currentMdph, currentUser, banetteUser, toastr) {
     this.token = $cookies.get('token');
     this.status = status;
     this.requests = requests;
     this.groupedByAge = groupedByAge;
     this.banetteUser = banetteUser;
+    $scope.layoutctrl.currentUser = currentUser;
+
     this.groups = [
       {
         id: 'new',


### PR DESCRIPTION
A chaque déconnexion d'un utilisateur autre, puis reconnexion en tant qu'agent : 

 - le panneau de navigation à gauche affiche soit :
  - la moitié de la partie "Flux de demandes" (la moitié *Toutes les demandes*)
  - uniquement la partie gestion des comptes agents
 - Le rafraîchissement de la page permet de tout afficher comme attendu

Attendu : 

 - Le rafraîchissement de la page par l'utilisateur ne devrait pas être nécessaire