### PR TITLE
[Ano lot3.2 - Mantis 7086] [Formulaire - Vie au travail] Erreur de suppression lors du clic sur "Précédent"

### DIFF
--- a/client/app/demande/projet_de_vie/vie_au_travail/situation_professionnelle.js
+++ b/client/app/demande/projet_de_vie/vie_au_travail/situation_professionnelle.js
@@ -110,21 +110,7 @@ angular.module('impactApp')
       templateUrl: 'components/question/employeur.html',
       authenticate: true,
       authorized: ['user'],
-      controller: function($scope, question, prevStep, nextStep) {
-        if (angular.isUndefined($scope.sectionModel.employeur)) {
-          $scope.sectionModel.employeur = {
-            nom: {label: 'Nom', value: ''},
-            adresse: {label: 'Adresse', value: ''},
-            medecin: {label: 'Service/Médecin', value: ''}
-          };
-        }
-
-        $scope.question = question;
-        $scope.nextStep = nextStep;
-        $scope.prevStep = prevStep;
-        $scope.model = $scope.sectionModel.employeur;
-      },
-
+      controller: 'QuestionCtrl',
       resolve: {
         question: function(QuestionService, section, profile) {
           return QuestionService.get(section, 'employeur', profile);

--- a/client/components/question/employeur.html
+++ b/client/components/question/employeur.html
@@ -2,15 +2,15 @@
   <qtitle ng-hide="hideTitle"></qtitle>
 
   <div class="form-group">
-    <label class="control-label" for="employeur-name">{{model.nom.label}}</label>
-    <input type="text" name="employeurName" id="employeur-name" class="form-control" ng-model="model.nom.value" placeholder="Nom" required>
+    <label class="control-label" for="employeur-name">{{sectionModel[question.model].nom.label}}</label>
+    <input type="text" name="employeurName" id="employeur-name" class="form-control" ng-model="sectionModel[question.model].nom.value" placeholder="Nom" required>
     <div ng-messages="questionForm.employeurName.$error" ng-if="questionForm.showError">
       <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
     </div>
   </div>
   <div class="form-group">
-    <label class="control-label" for="employeur-adresse">{{model.adresse.label}}</label>
-    <textarea rows="4" name="employeurAdresse" id="employeur-adresse" class="form-control" ng-model="model.adresse.value" placeholder="Adresse" required></textarea>
+    <label class="control-label" for="employeur-adresse">{{sectionModel[question.model].adresse.label}}</label>
+    <textarea rows="4" name="employeurAdresse" id="employeur-adresse" class="form-control" ng-model="sectionModel[question.model].adresse.value" placeholder="Adresse" required></textarea>
     <div ng-messages="questionForm.employeurAdresse.$error" ng-if="questionForm.showError">
       <div class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</div>
     </div>

--- a/client/components/question/question.controller.js
+++ b/client/components/question/question.controller.js
@@ -25,6 +25,7 @@ angular.module('impactApp')
 
       // Si pas encore de réponse, on reprend la dernière
       if (previousModel && !sectionModel[question.model]) {
+        console.info('previousModel:', previousModel[question.model]);
         sectionModel[question.model] = previousModel[question.model];
 
         if (question.answers) {
@@ -33,6 +34,15 @@ angular.module('impactApp')
           });
         }
       }
+
+      if (!previousModel && !sectionModel[question.model] && question.model === 'employeur') {
+        sectionModel[question.model] = {
+          nom: {label: 'Nom', value: ''},
+          adresse: {label: 'Adresse', value: ''},
+          medecin: {label: 'Service/Médecin', value: ''}
+        };
+      }
+
     };
   })
   .controller('QuestionCtrl', function($scope, $state, question, previousModel, sectionModel, nextStep, initQuestionScope, prevStep) {

--- a/client/components/question/question.controller.js
+++ b/client/components/question/question.controller.js
@@ -25,7 +25,6 @@ angular.module('impactApp')
 
       // Si pas encore de réponse, on reprend la dernière
       if (previousModel && !sectionModel[question.model]) {
-        console.info('previousModel:', previousModel[question.model]);
         sectionModel[question.model] = previousModel[question.model];
 
         if (question.answers) {


### PR DESCRIPTION
Constaté le 09/05/2018 : 

Lorsque l'usager saisit des réponses à la question "Qui est votre employeur", les réponses ne sont pas supprimées s'il clique sur le bouton "Précédent". 

Par conséquent, s'il change de chemin suite à une erreur, l'information est tout de même enregistrée dans la demande et affichée dans le PDF récapitulatif. 

Pourriez-vous mettre en place le même fonctionnement que pour les autres questions ? A savoir : 
Suppression des informations saisies lors du clic sur "Précédent". 