### PR TITLE
[Ano lot3.2 - Mantis 7087] [Usager - PDF récapitulatif] Identité du bénéficiaire - Nationalité

### DIFF
--- a/server/components/templates/identite.html
+++ b/server/components/templates/identite.html
@@ -20,6 +20,12 @@
 </p>
 {{/if}}
 
+{{#if nationalite}}
+<p>
+  Nationalité: <strong>{{nationalite}}</strong>
+</p>
+{{/if}}
+
 {{#if type}}
 <p>
   Type: <strong>{{type}}</strong>


### PR DESCRIPTION
Constaté le 14/05/2018 :

Dans le formulaire "Identité du bénéficiaire", la nationalité est manquante sur le récapitulatif affiché dans l'application ainsi que sur le PDF.