### PR TITLE
[Ano lot3.2 - Mantis 7092] [Usager - PDF récapitulatif] Vie scolaire ou étudiante - Ordre d'affichage

### DIFF
--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -837,11 +837,6 @@
           }
         ]
       },
-      "etablissement": {
-        "model": "etablissement",
-        "titleDefault": "Dans quel(s) établissement(s) ?",
-        "type": "etablissement"
-      },
       "internat": {
         "model": "internat",
         "titleDefault": "Est-il placé en internat ?",
@@ -860,6 +855,11 @@
             "model": false
           }
         ]
+      },
+      "etablissement": {
+        "model": "etablissement",
+        "titleDefault": "Dans quel(s) établissement(s) ?",
+        "type": "etablissement"
       },
       "typeEtudes": {
         "model": "typeEtudes",


### PR DESCRIPTION
Constaté le 14/05/2018 :

Les questions "Est-il placé en internat" (A) et "Dans quel établissement ?" (B) doivent être inversées dans le PDF récapitulatif afin d'apparaître dans cet ordre (A - B).