### PR TITLE
[Ano lot3.2 - Mantis 7094] [Usager - PDF récapitulatif] Vie au travail - Question "Avez-vous actuellement un emploi ?"

### DIFF
--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -1205,7 +1205,7 @@
             "detailUrl": "components/detail/precisez_date.html",
             "detailModel": "conditionTravailDetail",
             "detailLabel": "Depuis quand ?",
-            "detailType": "date"
+            "detailType": "depuis"
           },
           {
             "label": "Non",


### PR DESCRIPTION
Lorsque la date est saisie, le PDF indique : 
"* Oui
    ° 11/11/1111"

Il faudrait ajouter "Depuis le" avant la date, tel que : 
"* Oui
    ° Depuis le 11/11/1111"