### PR TITLE
[Ano lot3.2 - Mantis 7095] [Usager - PDF récapitulatif] Vie au travail - Question "Êtes-vous actuellement en arrêt de travail ?"

### DIFF
--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -1453,7 +1453,7 @@
             "detailUrl": "components/detail/precisez_date.html",
             "detailModel": "arretDeTravailDetail",
             "detailLabel": "Depuis quand ?",
-            "detailType": "date"
+            "detailType": "depuis"
           },
           {
             "label": "Non",


### PR DESCRIPTION
Constaté le 14/05/2018 :

Lorsque la date est saisie, le PDF indique :
"* Oui
° 11/11/1111"

Il faudrait ajouter "Depuis le" avant la date, tel que :
"* Oui
° Depuis le 11/11/1111"