### PR TITLE
[Ano lot3.2 - Mantis 7049] [Usager - Formulaire] Situations particuliaires - Orthographe du message d'erreur

### DIFF
--- a/client/components/detail/precisez_date_et_detail.html
+++ b/client/components/detail/precisez_date_et_detail.html
@@ -15,7 +15,7 @@
         aria-describedby="help-date">
         <div ng-messages="questionForm['date_' + answer.detailModel].$error" ng-if="questionForm.showError">
           <p class="help-block" ng-message='inputDate'><i class="fa fa-warning"></i> Veuillez utiliser le format JJ/MM/AAAA. Par exemple : 14/09/1989.</p>
-          <p class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire.</p>
+          <p class="help-block" ng-message='required'><i class="fa fa-warning"></i> Ce champ est obligatoire</p>
         </div>
     </div>
   </div>


### PR DESCRIPTION
Correction du ticket initial OK
[Constaté le 19/03/2018]

L'icone [fa-warning] devant le message d'erreur "/!\ Ce champ est obligatoire" associées aux réponses :

    "Vous commencez bientôt une nouvelle formation"
    et
    "Vous venez de trouver un emploi"

a bien été ajouté, cependant, il manque un espace entre l'icone et le message.