### PR TITLE
[Ano lot3.2 - Mantis 7105] [Usager - PDF récapitulatif et Formulaire] Prestations - Parcours de scolarisation

### DIFF
--- a/server/api/prestation/prestations.json
+++ b/server/api/prestation/prestations.json
@@ -91,7 +91,7 @@
     "id": "pps",
     "type": "enfant",
     "label": "PPS",
-    "title": "Parcours de scolarisation et/ou de formation avec ou sans accompagnement par un établissement ou service médico-social.",
+    "title": "Parcours de scolarisation et/ou de formation avec ou sans accompagnement par un établissement ou service médico-social",
     "description": "Le PPS fait partie du Plan de compensation du handicap (PCH). Il définit les modalités de déroulement de la scolarité et les actions pédagogiques, psychologiques, éducatives,sociales, médicales et paramédicales répondant aux besoins particuliers des élèves présentant un handicap.",
     "link": "http://www.education.gouv.fr/pid25535/bulletin_officiel.html&cid_bo=86108"
   },


### PR DESCRIPTION
Constaté le 14/05/2018 :

La prestation "Parcours de scolarisation et/ou de formation avec ou sans accompagnement par un établissement ou service médico-social." est la seule à avoir un point en fin de phrase. Serait-il possible de le retirer ?