### PR TITLE
[Ano lot3.2 - Mantis 7091] [Usager - PDF récapitulatif et formulaire] Vie scolaire ou étudiante - Question "Est-il placé en internat"

### DIFF
--- a/server/api/sections/sections.json
+++ b/server/api/sections/sections.json
@@ -844,7 +844,7 @@
       },
       "internat": {
         "model": "internat",
-        "titleDefault": "Est-il placé en internat ?",
+        "titleDefault": "Êtes-vous placé en internat ?",
         "type": "radio",
         "answers": [
           {


### PR DESCRIPTION
 Constaté le 14/05/2018 :

Dans le formulaire "Vie scolaire ou étudiante" adulte (>20 ans) et dans les PDF récapitulatifs (Adulte et enfant), modifier la question à la deuxième personne du pluriel :
"Êtes-vous placé en internat ?"