### PR TITLE
[Ano lot4 - Mantis 7155] [Agent][Tableau des demandes validées] : Passage 'validée' à 'irrecevable' autorisé

### DIFF
--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -26,7 +26,7 @@
           <li role="menuitem" ng-if="workflowListCtrl.showDownloadAndDeleteButtons">
             <a href="#" ng-click="workflowListCtrl.downloadRequests()"><i class="fa fa-download"></i> Télécharger les demandes</a>
           </li>
-          <li role="menuitem" ng-if="workflowListCtrl.status !== 'irrecevable'">
+          <li role="menuitem" ng-if="workflowListCtrl.status !== 'irrecevable' && workflowListCtrl.status !== 'validee' ">
             <a href="#" ng-click="workflowListCtrl.openIrrecevableModal()"><i class="fa fa-archive"></i> Marquer comme irrecevable</a>
           </li>
           <li role="menuitem" ng-if="workflowListCtrl.status === 'validee' || workflowListCtrl.status === 'irrecevable'">


### PR DESCRIPTION
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Connecté en tant qu'agent, il est actuellement possible de faire passer une demande "validée" à l'état "irrecevable". Cette transition n'a pas été autorisée dans les workflow, merci de retirer l'option "marquer comme irrecevable" de la liste des actions possibles sous le bouton d'actions groupées.