### PR TITLE
[RC lot4 - mantis 7132 - P0] [Technique][Agent] : Téléchargement d'une demande supprimée

### DIFF
--- a/client/app/dashboard/workflow/workflow.controller.js
+++ b/client/app/dashboard/workflow/workflow.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('impactApp')
-  .controller('WorkflowCtrl', function($scope, $modal, $window, $cookies, $state, $http, RequestResource) {
+  .controller('WorkflowCtrl', function($scope, $modal, $window, $cookies, $state, $http, RequestResource, toastr) {
     this.token = $cookies.get('token');
     this.openDeleteModal = function(request) {
       $modal.open({
@@ -44,9 +44,13 @@ angular.module('impactApp')
 
     this.download  = function(request) {
       request.isDownloaded = 'true';
-      RequestResource.update(request).$promise.then(result => {
-        $window.open('api/requests/' + result.shortId + '/pdf/agent?access_token=' + this.token, '_self');
-      });
+      if (request.deletedAt) {
+        toastr.error('La demande correspondant à la référence ' + request.shortId + ' a été supprimée.', 'Erreur');
+      } else {
+        RequestResource.update(request).$promise.then(result => {
+          $window.open('api/requests/' + result.shortId + '/pdf/agent?access_token=' + this.token, '_self');
+        });
+      }
     };
 
   });

--- a/server/api/request/request.controller.js
+++ b/server/api/request/request.controller.js
@@ -364,6 +364,7 @@ export function getRecapitulatif(req, res) {
 
 export function getPdf(req, res) {
   var currentMdph = null;
+  if (req.request.deletedAt) return res.sendStatus(404);
   Mdph
     .findOne({zipcode: req.request.mdph})
     .exec()


### PR DESCRIPTION
En tant qu'agent, il est possible de télécharger une demande déjà supprimée.

Scénarios envisagés :

actualisation d'un lien téléchargement alors que par ailleurs la demande a déjà été supprimée
usage concurrentiel du tableau de bord par 2 agents, l'un supprime, l'autre télécharge.
Les conséquences de cette simple requête à l'API sont alors fatales au service qui est automatiquement mis hors service.

Il semble préférable, pour la disponibilité du service, de gérer l'exception "requête de téléchargement d'une demande supprimée".