### PR TITLE
[RC lot4 - Mantis 7158 - P1] [Agent][Tableau des demandes] : Bouton rafraîchir ne fonctionne pas

### DIFF
--- a/client/app/dashboard/workflow/list/list.controller.js
+++ b/client/app/dashboard/workflow/list/list.controller.js
@@ -168,6 +168,7 @@ angular.module('impactApp')
         this.groupedByAge = RequestService.groupByAge(this.requests);
         this.isRefreshing = false;
       });
+      $state.go('.', {}, {reload: true});
     };
 
     this.allSelectedRequestsDownloadOpenModal = function() {

--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -36,7 +36,7 @@
           </li>
         </ul>
 
-        <button type="button" class="btn btn-link btn-refresh" ng-class="{ 'refreshing': workflowlistctrl.isRefreshing }" ng-click="workflowlistctrl.refresh()">
+        <button type="button" class="btn btn-link btn-refresh" ng-class="{ 'refreshing': workflowListCtrl.isRefreshing }" ng-click="workflowListCtrl.refresh()">
           Rafraîchir
         </button>
       </div>


### PR DESCRIPTION
Connecté en tant qu'agent, sur tous les tableaux de bord de gestion des demandes (mes demandes, toutes les demandes) et tous états, le bouton "Rafraîchir" ne fonctionne pas.