### PR TITLE
lot4 - Mantis 7146 [Usager][Gestion des demandes] : Anomalies graphiques

### DIFF
--- a/client/app/gestion/demande/gestion.demande.controller.js
+++ b/client/app/gestion/demande/gestion.demande.controller.js
@@ -67,13 +67,13 @@ angular.module('impactApp')
         case 'emise':
           return 'Emise';
         case 'validee':
-          return 'validée';
+          return 'Validée';
         case 'en_attente_usager':
           return 'En attente';
         case 'irrecevable':
-          return 'irrecevable';
+          return 'Irrecevable';
         default:
-          return 'indéfinie';
+          return 'Indéfinie';
       }
     };
   });

--- a/client/app/gestion/demande/gestion.demande.html
+++ b/client/app/gestion/demande/gestion.demande.html
@@ -44,7 +44,7 @@
         <h2>Demande de {{ ::gestionDemandeCtrl.profil.getTitle() }} en cours</h2>
         <div class="row" ng-if="gestionDemandeCtrl.currentDemande && !showMenu">
           <div class="col-flex5 col-icon-demande left-radius" ng-click="gestionDemandeCtrl.goCurrentDemande()">{{ gestionDemandeCtrl.currentDemande.shortId }}</div>
-          <div class="col-flex5 col-item" ng-click="gestionDemandeCtrl.goCurrentDemande()">Créé le {{gestionDemandeCtrl.currentDemande.createdAt | date:'dd/MM/yyyy'}}</div>
+          <div class="col-flex5 col-item" ng-click="gestionDemandeCtrl.goCurrentDemande()">Créée le {{gestionDemandeCtrl.currentDemande.createdAt | date:'dd/MM/yyyy'}}</div>
           <div class="col-flex5 col-item right-radius" align="right" ng-click="gestionDemandeCtrl.goCurrentDemande()">{{ gestionDemandeCtrl.showStatus(gestionDemandeCtrl.currentDemande) }}</div>
           <div class="col-flex3 col-action left-radius right-radius" align="center" ng-click="gestionDemandeCtrl.deleteCurrentDemande()">Supprimer</div>
         </div>

--- a/client/app/gestion/demande/gestion.demande.html
+++ b/client/app/gestion/demande/gestion.demande.html
@@ -8,16 +8,16 @@
 </header>
 
 <section class="section-gestion container-fluid">
-  <div class="row">
+  <div class="rowMenu">
 
-    <div ng-class="{'col-md-1':!showMenu}" style="width:15%" ng-if="!showMenu">
+    <div ng-class="{'col-md-2':!showMenu}" ng-if="!showMenu">
         <button ui-sref="gestion_profil" class="btn retour">
             Retour aux profils
         </button>
         <div class="icon-demande centre"/>
     </div>
 
-    <div ng-class="{'col-md-11 border-left':!showMenu}" style="width:85%">
+    <div ng-class="{'col-md-10 border-left':!showMenu}">
 
       <div class="breadcrump">
         <div class="breadcrump-section">
@@ -49,8 +49,8 @@
           <div class="col-flex3 col-action left-radius right-radius" align="center" ng-click="gestionDemandeCtrl.deleteCurrentDemande()">Supprimer</div>
         </div>
         <div class="row" ng-if="gestionDemandeCtrl.currentDemande && showMenu">
-          <div style="width:80%" class="col-xs-11 col-icon-demande left-radius right-radius" ng-click="gestionDemandeCtrl.goCurrentDemande()">{{ gestionDemandeCtrl.currentDemande.shortId }}</div>
-          <div style="width:20%" class="col-xs-1 col-action left-radius right-radius" ng-click="gestionDemandeCtrl.deleteCurrentDemande()"></div>
+          <div class="col-flex6 col-icon-demande left-radius right-radius" ng-click="gestionDemandeCtrl.goCurrentDemande()">{{ gestionDemandeCtrl.currentDemande.shortId }}</div>
+          <div class="col-flex1 col-action centre left-radius right-radius" ng-click="gestionDemandeCtrl.deleteCurrentDemande()"></div>
         </div>
         <div class="row">
           <div class="col-md-12 left-radius right-radius"
@@ -64,7 +64,7 @@
         <h2 ng-if="gestionDemandeCtrl.archivedDemandes.length > 0">Demandes de {{ ::gestionDemandeCtrl.profil.getTitle() }} archivées</h2>
         <div class="row" ng-repeat="(idx, archivedDemande) in gestionDemandeCtrl.archivedDemandes" ng-if="!showMenu">
           <div class="col-flex5 col-icon-demande-desabled left-radius">{{ archivedDemande.shortId }}</div>
-          <div class="col-flex7 col-item-desabled">Créé le {{archivedDemande.createdAt | date:'dd/MM/yyyy'}} - Archivée le {{ archivedDemande.updatedAt | date:'dd/MM/yyyy'}}</div>
+          <div class="col-flex7 col-item-desabled">Créée le {{archivedDemande.createdAt | date:'dd/MM/yyyy'}} - Archivée le {{ archivedDemande.updatedAt | date:'dd/MM/yyyy'}}</div>
           <div class="col-flex3 col-item-desabled right-radius" align="right">{{ gestionDemandeCtrl.showStatus(archivedDemande) }}</div>
           <div class="col-flex3 col-action-desabled left-radius right-radius" align="center">Demande archivée</div>
         </div>

--- a/client/app/gestion/gestion.scss
+++ b/client/app/gestion/gestion.scss
@@ -12,6 +12,13 @@
     display: flex;
   }
 
+  .rowMenu {
+    max-width: 100% !important;
+    margin-bottom: 14px;
+    margin-top: 14px;
+    display: flex;
+  }
+
   .col {
     margin: 4px;
     flex: 1;
@@ -156,6 +163,7 @@
     text-align: center;
     border-radius: 3px;
     min-height: 44px;
+    width: 90%;
 
     &.espace {
       margin-left: 28px;
@@ -170,6 +178,9 @@
     padding: 10px 15px;
     font-size: 1.2em;
     color: #FFFFFF;
+    &.centre {
+      text-align: center;
+    }
 
     &:before {
       content: "\f1f8";


### PR DESCRIPTION

Pour harmonisation avec la page de gestion des profils :

1. la colonne de droite qui sert à l'affichage de l'icône demande, occupe 15% de l'écran, merci de retirer l'élément style de la div et laisser une largeur définie par bootstrap : col-md-2
2. le bouton de retour aux profils devrait également occuper toute la largeur de la colonne de droite
3. de même retirer la définition de largeur sur le corps de la page et utiliser les largeurs définies par défaut : col-md-10

Plusieurs anomalies de libellés détectées :

1. merci de passer au féminin le participe passé du verbe créer pour les demandes archivées : "Créée"
2. les états affichés des demandes doivent être affichés comme suit, avec une majuscule :

- « Validée »
- « Irrecevable »