### PR TITLE
[RC lot4 - Mantis 7136 - P1] [Technique][Agent] : Anomalie dans les exports ZIP

### DIFF
--- a/server/components/pdf_utils/archive.js
+++ b/server/components/pdf_utils/archive.js
@@ -16,7 +16,8 @@ export default function(fileList, directory) {
       var archive = archiver.create('zip', {});
 
       fileList.forEach((file) => {
-        archive.append(fs.createReadStream(file.path), { name: file.name });
+        var filename = file.name.replace(" / ", "_").replace("/", "_");
+        archive.append(fs.createReadStream(file.path), { name: filename });
       });
 
       archive.on('finish', function() {


### PR DESCRIPTION
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

La présence du caractère "/" dans les éléments suivants est mal géré lors d'export ZIP d'une demande :

- le nom de la catégorie ;
- le nom d'un type de documents (classé dans une catégorie).

En effet, le caractère / est interprété comme un chemin dans l'archive et les documents téléchargés sont inexploitables.

Lors de la génération de l'archive ZIP, il faudrait peut être remplacer le "/" par "_" afin que l'anomalie ne soit plus observée.