### PR TITLE
[RC lot4 - Mantis 7152 - P2] [Agent][Détail d'une demande] : Vie de la demande illisible

### DIFF
--- a/client/components/timeline/action-types.constant.js
+++ b/client/components/timeline/action-types.constant.js
@@ -26,7 +26,7 @@ angular.module('impactApp')
       label: 'Refus de document',
       fa: 'thumbs-down',
     },
-    update_answers: {
+    update_data: {
       label: 'Mise à jour des réponses',
       fa: 'edit',
     },


### PR DESCRIPTION
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Connecté en tant qu'agent, 

- la vie de la demande consultable dans l'onglet "vie de la demande" de la fiche détail d'une demande n'est pas lisible.

- De nombreuses actions "de type inconnu" sont enregistrées, que ce soit des actions des agents ou des actions des usagers.