### PR TITLE
[RC lot4 - Mantis 7154 - P2] [Agent][Gestion des agents] : Révisions graphiques KO et [RC Lot4 - Mantis 7156 - P2] [Agent][Tableau des demandes] : Révisions graphiques KO

### DIFF
--- a/client/app/dashboard/workflow/list/list.html
+++ b/client/app/dashboard/workflow/list/list.html
@@ -27,7 +27,7 @@
             <a href="#" ng-click="workflowListCtrl.downloadRequests()"><i class="fa fa-download"></i> Télécharger les demandes</a>
           </li>
           <li role="menuitem" ng-if="workflowListCtrl.status !== 'irrecevable'">
-            <a href="#" ng-click="workflowListCtrl.openIrrecevableModal()"><i class="fa fa-archive"></i> Marquer comme irrecevable</a>
+            <a href="#" ng-click="workflowListCtrl.openIrrecevableModal()"><i class="fa fa-ban"></i> Marquer comme irrecevable</a>
           </li>
           <li role="menuitem" ng-if="workflowListCtrl.status === 'validee' || workflowListCtrl.status === 'irrecevable'">
               <a href="#" ng-click="workflowListCtrl.allSelectedRequestsDownloadOpenModal()">
@@ -113,7 +113,7 @@
           </td>
           <td class="col-md-2">
             <button ng-show="workflowListCtrl.showDownloadAndDeleteButtons && request.isDownloaded" class="btn btn-link red-color" ng-click="workflowCtrl.openDeleteModal(request)">
-              <i class="fa fa-trash"></i>&nbsp;Supprimer</i>
+              <i class="fa fa-trash"></i>&nbsp;Supprimer
             </button>
           </td>
         </tr>


### PR DESCRIPTION
7156
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Pour les agents MDPH, nous avions demandé plusieurs ajustements graphiques de l'interface de gestion des demandes.
Un élément n'a pas été réalisé : l'icône associée à l'action « Marquer comme irrecevable » doit être un "interdit" : [fa fa-ban]

-------------------------------------------------
7154
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Connecté en tant qu'agent, plusieurs défauts sont observables sur les interfaces de gestion des agents :

1. les boutons "Annuler" et "Sauvegarder" présents sur les pages de création et modification d'un agent ne sont pas correctement alignés sur un petit écran (13 pouces) : "Annuler" se trouve au-dessus de "Sauvegarder" alors qu'il avait été explicitement demandé à ce que les boutons soient sur la même ligne.
2. le bouton "supprimer" ne présente pas la bonne icône sur la page de modification d'un agent. Il a été explicitement demandé de mettre l'icône poubelle [fa fa-trash] comme précisé dans l'expression de besoins.