### PR TITLE
[RC lot4 - Mantis 7139] [Usager][Saisie demande - Document] : Rechargement intempestif de la page

### DIFF
--- a/client/app/demande/documents/documents.controller.js
+++ b/client/app/demande/documents/documents.controller.js
@@ -16,13 +16,7 @@ angular.module('impactApp').controller('DemandeDocumentsCtrl', function(
     FileSignatureService.check(file, ['pdf', 'jpg', 'png'])
       .then(function(result) {
         if (result) {
-          UploadService.upload(demande, file, documentType).then(function(resp) {
-            console.log('resp : ',  resp);
-            $http.get(`/api/requests/${demande.shortId}`).then(function(result) {
-              demande = result.data;
-              $state.go('^.documents', {}, {reload: true});
-            });
-          });
+          UploadService.upload(demande, file, documentType);
         } else {
           $scope.$emit('file-upload-error', documentType.id);
         }

--- a/client/components/service/upload.service.js
+++ b/client/components/service/upload.service.js
@@ -1,10 +1,9 @@
 'use strict';
 
 angular.module('impactApp')
-  .factory('UploadService', function UploadService(Upload, $rootScope, $q) {
+  .factory('UploadService', function UploadService(Upload, $rootScope) {
     return {
       upload: function(demande, file, documentType) {
-        var deferred = $q.defer();
 
         if (!file) {
           return;
@@ -50,7 +49,6 @@ angular.module('impactApp')
         }).then(function(resp) {
           model[documentType.id].documentList.pop();
           model[documentType.id].documentList.push(resp.data);
-          deferred.resolve(resp);
         },
 
         function() {
@@ -62,7 +60,6 @@ angular.module('impactApp')
           uploadedFile.progress = parseInt(100.0 * evt.loaded / evt.total);
         });
 
-        return deferred.promise;
       }
     };
   });

--- a/server/api/document/document.controller.js
+++ b/server/api/document/document.controller.js
@@ -114,7 +114,7 @@ export function saveFile(req, res) {
 
       request.saveActionLog(ACTIONS.DOCUMENT_ADDED, req.user, req.log, {document: document});
 
-      var savedDocument = _.find(saved.documents, {filename: document.filename});
+      var savedDocument = _.find(saved.data.documents, {filename: document.filename});
       return res
         .status(201)
         .json(savedDocument);


### PR DESCRIPTION
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Connecté en tant qu'usager, il est très désagréable d'utiliser la page d'upload des documents lorsque l'on remplit initialement le questionnaire ou que la demande est en attente : 

- l'upload d'un document engendre systématiquement un rechargement de la page, l'utilisateur perd le focus (position à laquelle il était dans la page),
- si le premier upload n'est pas terminé et que l'utilisateur lance un second upload, ce-dernier est interrompu

Ces deux comportements ne sont pas satisfaisants, merci de les corriger.