### PR TITLE
[RC lot4 - Mantis 7147 - P2] [Usager][Gestion des demandes] : Erreur dans les messages de suppression et [RC lot4 - Mantis 7144 - P2] [Usager][Gestion des profils] : Erreur dans les messages de suppression

### DIFF
--- a/client/app/gestion/demande/delete_confirmation.html
+++ b/client/app/gestion/demande/delete_confirmation.html
@@ -3,12 +3,11 @@
 </div>
 
 <div class="modal-body">
-  <p ng-if="deleteDemandeConfirmationCtrl.demande.status === 'en_cours'">Voulez-vous vraiment supprimer la demande n°<strong>{{deleteDemandeConfirmationCtrl.demande.shortId}}</strong> ? <br/> Cette suppression est définitive.</p>
-  <p ng-if="deleteDemandeConfirmationCtrl.demande.status !== 'en_cours'">Vous ne pouvez pas supprimer la demande n°<strong>{{deleteDemandeConfirmationCtrl.demande.shortId}}</strong> via ce service.</p>
+  <p>Voulez-vous vraiment supprimer la demande n° <strong>{{deleteDemandeConfirmationCtrl.demande.shortId}}</strong> ? <br/> Cette suppression est définitive.</p>
   <div ng-if="deleteDemandeConfirmationCtrl.demande.status !== 'en_cours'" class="alert alert-warning">
     <p>
       Cette demande a été transmise à votre MDPH. <br/>
-      Pour toutes demandes de supression des données associées à cette demande, merci de contacter votre MDPH, dont les coordonnées sont affichées en bas de page.
+      Pour toutes demandes de suppression des données associées à cette demande, merci de contacter votre MDPH, dont les coordonnées sont affichées en bas de page.
     </p>
   </div>
 </div>

--- a/client/app/gestion/profil/delete_confirmation.html
+++ b/client/app/gestion/profil/delete_confirmation.html
@@ -3,15 +3,16 @@
 </div>
 
 <div class="modal-body">
-  <p>Voulez-vous vraiment supprimer le profil de <strong>{{deleteProfilConfirmationCtrl.profil.getTitle()}}</strong> ? Cette suppression est définitive.</p>
-  <div ng-if="deleteProfilConfirmationCtrl.demandes.length" class="alert alert-warning">
+  <p ng-if="deleteProfilConfirmationCtrl.demandes.length === 0">Voulez-vous vraiment supprimer le profil de <strong>{{deleteProfilConfirmationCtrl.profil.getTitle()}}</strong> et la demande associée? Cette suppression est définitive.</p>
+  <p ng-if="deleteProfilConfirmationCtrl.demandes.length > 0">Voulez-vous vraiment supprimer le profil de <strong>{{deleteProfilConfirmationCtrl.profil.getTitle()}}</strong> ? Cette suppression est définitive."</p>
+  <div ng-if="deleteProfilConfirmationCtrl.demandes.length > 0" class="alert alert-warning">
     <p ng-if="deleteProfilConfirmationCtrl.demandes.length === 1">
-      Vous avez 1 demande associée à ce profil déjà transmise à une MDPH. <br>
-      Pour une supression totale de cette demande, merci de contacter votre MDPH dont les coordonnées sont affichées en bas de la page.
+        Vous avez une demande associée à ce profil déjà transmise à une MDPH. <br/>
+        Pour toute demande de suppression des données associées à cette demande, merci de contacter votre MDPH dont les coordonnées sont affichées en bas de page.
     </p>
     <p ng-if="deleteProfilConfirmationCtrl.demandes.length > 1">
-      Vous avez {{ deleteProfilConfirmationCtrl.demandes.length }} demandes associées à ce profil déjà transmises à une MDPH. <br>
-      Pour une supression totale de ces demandes, merci de contacter votre MDPH dont les coordonnées sont affichées en bas de la page.
+      Vous avez {{ deleteProfilConfirmationCtrl.demandes.length }} demandes associées à ce profil déjà transmises à une MDPH. <br/>
+      Pour toute demande de suppression des données associées à ces demandes, merci de contacter votre MDPH dont les coordonnées sont affichées en bas de page.
     </p>
   </div>
 </div>


### PR DESCRIPTION
7147
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Nous avons demandé que 2 types de messages soit proposés sur le tableau de bord de gestion des demandes lors de la suppression d'une demande :

1. message lorsque la demande supprimée est en cours de création

*"Voulez-vous vraiment supprimer la demande n°_______?
Cette suppression est définitive."*

2. message dans tout autre cas avec une alerte

*"Voulez-vous vraiment supprimer la demande n°_______?
Cette suppression est définitive.
[Cette demande a été transmise à votre MDPH.
Pour toutes demandes de suppression des données associées à cette demande, merci de contacter votre MDPH, dont les coordonnées sont affichées en bas de page.] "*

Dans le cas 2, il y a une faute d'orthographe sur le mot "suppression". Merci de la corriger.

---------------------------------------------
7144
 Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Nous avons demandé que 2 types de messages soit proposés sur le tableau de bord de gestion des profils usagers lors de la supression d'un profil :

1. message lorsque le profil supprimé est associé uniquement à une demande en cours

 - "Voulez-vous vraiment supprimer le profil de [Profil en cours de saisie || Nom du profil] et la demande associée? Cette suppression est définitive."

2. message dans tout autre cas

 - "Voulez-vous vraiment supprimer le profil de [Nom du profil] ? Cette suppression est définitive." 
 - Message encadré : " Vous avez x demande.s associée.s à ce profil déjà transmise.s à une MDPH. Pour toute demande de suppression des données associées à cette/ces demande.s, merci de contacter votre MDPH dont les coordonnées sont affichées en bas de page."

Ces 2 messages n'ont pas été correctement intégrés, merci de reprendre les définitions proposées dans l'expression de besoins.

Cf. PJ pour l'EBE