### PR TITLE
[RC lot4 - Mantis 7150 - P2] [Usager][Pop-In Visualisation] : pop-in trop grande

### DIFF
--- a/client/app/demande/demande-preview-modal.html
+++ b/client/app/demande/demande-preview-modal.html
@@ -6,7 +6,7 @@
     <h4>Une fois la demande validée, vous ne pourrez plus modifier d'autres informations que les documents, et ce sur demande de la MDPH. Vous pourrez trouver ci-dessous le récapitulatif de votre demande : </h4>
 
     <h3>Récapitulatif de votre demande</h3>
-    <div class="embed-responsive embed-responsive-16by9">
+    <div class="embed-responsive embed-responsive-preview">
       <iframe ng-src="{{'/api/requests/' + demandePreviewModalCtrl.demande.shortId + '/recapitulatif?access_token=' + demandePreviewModalCtrl.token}}" class="embed-responsive-item"></iframe>
     </div>
     <br/>
@@ -18,7 +18,6 @@
       </ul>
     </div>
     <br/>
-
 
     <div class="text-center"><h4>En validant, je certifie que les informations ci-dessus sont exactes.</h4></div>
 

--- a/client/app/demande/demande.scss
+++ b/client/app/demande/demande.scss
@@ -101,3 +101,7 @@ section.profile-section {
   display: inline-block;
   letter-spacing: 2px;
 }
+
+.embed-responsive-preview {
+  padding-bottom: 50%;
+}


### PR DESCRIPTION
Constaté le 05/06 suite à la livraison de la version 0.4.0 le 30/05 :

Connecté en tant qu'usager, au moment d'envoyer la demande, la pop-in de prévisualisation est relativement grande.
Cela est agréable quand l'on dispose d'un grand écran, sur un petit écran, on risque de passer à côté des boutons d'envoi de la demande.

Il serait donc préférable de redimensionner l'iframe de prévisualisation de la demande afin que celle-ci : s'adapte à la hauteur de l'écran et n'excède pas la hauteur de l'écran. On verrait alors le premier fichier à télécharger et devinerait que les boutons d'envoi sont situés en bas.