### PR TITLE
[RC lot4 - mantis 7153 - P2] [Usager][Gestion des profils et demandes] : Responsive W. Design

### DIFF
--- a/client/app/gestion/gestion.scss
+++ b/client/app/gestion/gestion.scss
@@ -12,6 +12,15 @@
     display: flex;
   }
 
+  .smallRow {
+    max-width: 100% !important;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-bottom: 6px;
+    margin-top: 6x;
+    display: flex;
+  }
+
   .rowMenu {
     max-width: 100% !important;
     margin-bottom: 14px;
@@ -52,8 +61,8 @@
     flex: 7;
   }
 
-  .col-flex8 {
-    flex: 8;
+  .col-flex11 {
+    flex: 11;
   }
 
   .left-radius {
@@ -301,7 +310,7 @@
       position: relative;
       display: block;
       height: 44px;
-      padding: 10px 15px;
+      padding: 10px;
       float: left;
       background-color: white;
 

--- a/client/app/gestion/profil/gestion.profil.html
+++ b/client/app/gestion/profil/gestion.profil.html
@@ -40,14 +40,14 @@
           <div class="col-flex6 col-item right-radius" align="right" ng-click="gestionProfilCtrl.goProfil(profil)">{{ gestionProfilCtrl.showCurrentRequestStatus(profil) }}</div>
           <div class="col-flex2 col-action left-radius right-radius" align="center" ng-click="gestionProfilCtrl.deleteProfil(profil)">Supprimer</div>
         </div>
-        <div class="row" ng-repeat="(idx, profil) in gestionProfilCtrl.profils" ng-if="showMenu">
-          <div class="col-flex6 col-icon-profil " ng-click="gestionProfilCtrl.goProfil(profil)">{{ ::profil.getTitle() }}</div>
-          <div class="col-flex1 col-action" ng-click="gestionProfilCtrl.deleteProfil(profil)"></div>
+        <div class="smallRow" ng-repeat="(idx, profil) in gestionProfilCtrl.profils" ng-if="showMenu">
+          <div class="col-flex11 col-icon-profil left-radius right-radius" ng-click="gestionProfilCtrl.goProfil(profil)">{{ ::profil.getTitle() }}</div>
+          <div class="col-flex1 col-action left-radius right-radius" ng-click="gestionProfilCtrl.deleteProfil(profil)"></div>
         </div>
-        <div class="row" >
+        <div class="row" ng-class="{'smallRow': showMenu}">
           <div class="col-md-12 col-new left-radius right-radius" ng-click="gestionProfilCtrl.createProfil()">Créer un nouveau profil *</div>
         </div>
-        <div class="row" >
+        <div class="row" ng-class="{'smallRow': showMenu}" >
           <i class="note">* Le mode multi-profils permet d'effectuer des demandes pour plusieurs usagers</i>
         </div>
 
@@ -58,8 +58,8 @@
           <div class="col-flex5 col-item-desabled right-radius" align="right">{{ gestionProfilCtrl.showCurrentRequestSendedStatus(deletedProfil) }}</div>
           <div class="col-flex2 col-action-desabled left-radius right-radius" align="center">Profil supprimé</div>
         </div>
-        <div class="row" ng-repeat="(idx, deletedProfil) in gestionProfilCtrl.deletedProfils" ng-if="showMenu">
-          <div class="col-flex1  col-icon-profil-desabled">{{ ::deletedProfil.getTitle() }}</div>
+        <div class="smallRow" ng-repeat="(idx, deletedProfil) in gestionProfilCtrl.deletedProfils" ng-if="showMenu">
+          <div class="col-flex1 col-icon-profil-desabled left-radius right-radius">{{ ::deletedProfil.getTitle() }}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Sur la page de gestion des profils :

- le passage au responsive rend les boutons d'accès aux profils carrés, merci de reprendre un design avec des bords arrondis

Sur les pages de gestion des profils et page de gestion des demandes :

- sur de petits écrans, le fil d'Ariane "Profils > Demandes " n'est plus affiché convenablement : Demandes passe sous Profils en escalier
- les pages présentent des marges latérales trop importantes, nous pensons qu'il serait possible de gagner de la place (notamment pour les boutons supprimer)
- une passe globale en responsive sur ces deux écrans est attendue.