### PR TITLE
[lot4 - Mantis 7153 - bugfix01] Responsive Design de la gestion des profils

### DIFF
--- a/client/app/gestion/demande/gestion.demande.html
+++ b/client/app/gestion/demande/gestion.demande.html
@@ -20,18 +20,18 @@
     <div ng-class="{'col-md-10 border-left':!showMenu}">
 
       <div class="container-fluid">
-        <div ng-class="{'row':showMenu}" class="breadcrump">
-          <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
-            <div class=" first right-arrow">
-              <a ui-sref="gestion_profil"><span>Profils</span></a>
+          <div ng-class="{'row':showMenu, 'breadcrump':!showMenu}">
+              <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
+                  <div class=" first right-arrow" ng-class="{'whole':showMenu, 'large withMargin':!showMenu}">
+                    <a ui-sref="gestion_profil"><span>Profils</span></a>
+                  </div>
+                </div>
+                <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
+                    <div class="left-arrow last active" ng-class="{'whole':showMenu, 'large':!showMenu}">
+                      <span>Demandes</span>
+                    </div>
+                  </div>
             </div>
-          </div>
-          <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
-            <div class="left-arrow last active">
-              <span>Demandes</span>
-            </div>
-          </div>
-        </div>
       </div>
 
       <div class="container-fluid" ng-if="showMenu">

--- a/client/app/gestion/gestion.scss
+++ b/client/app/gestion/gestion.scss
@@ -17,7 +17,7 @@
     margin-left: 0px;
     margin-right: 0px;
     margin-bottom: 6px;
-    margin-top: 6x;
+    margin-top: 6px;
     display: flex;
   }
 
@@ -320,16 +320,26 @@
       padding: 10px 0px;
       float: left;
       background-color: white;
-      width: 177px;
+
+      &.whole {
+        width: 100%;
+      }
+
+      &.large{
+        width: 240px;
+      }
 
       span {
         padding: 0 20px;
       }
 
       &.first {
-        margin-left: 24px;
         border-top-left-radius: 5px;
         border-bottom-left-radius: 5px;
+      }
+
+      &.withMargin {
+        margin-left: 24px;
       }
 
       &.last {

--- a/client/app/gestion/profil/gestion.profil.html
+++ b/client/app/gestion/profil/gestion.profil.html
@@ -17,14 +17,14 @@
     <div ng-class="{'col-md-10 border-left':!showMenu}">
 
       <div class="container-fluid">
-        <div ng-class="{'rowMenu':showMenu}" class="breadcrump">
+          <div ng-class="{'row':showMenu, 'breadcrump':!showMenu}">
           <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
-            <div class="first right-arrow active">
+            <div class="first right-arrow active" ng-class="{'whole':showMenu, 'large withMargin':!showMenu}">
               <span>Profils</span>
             </div>
           </div>
           <div ng-class="{'col-flex6':showMenu}" class="breadcrump-section">
-            <div class="left-arrow last">
+            <div class="left-arrow last" ng-class="{'whole':showMenu, 'large':!showMenu}">
               <span>Demandes</span>
             </div>
           </div>


### PR DESCRIPTION
le fil d'Ariane et le bouton "Retour aux profil" doivent être de la même largeur que les boutons du tableau de bord : KO
Le fil d'Ariane est s'ajuste bien à la largeur du bouton "Retour profil"
Effet de bord : quand on met la fenêtre au plus petit (ou sur téléphone) on ne vois plus la partie droite de l'écran. Il faut scroller verticalement pour accéder au bouton supprimer.
La partie de droite a un fond d'écran blanc et non pas bleu.